### PR TITLE
Update composer.json for laravel 4.2 and update require-dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "4.0.* | 4.1.*"
+        "illuminate/support": "~4.0"
     },
     "require-dev": {
-        "orchestra/testbench": "2.0.* | 2.1.*",
-        "phpunit/phpunit": "3.7.*"
+        "orchestra/testbench": "~2.0",
+        "phpunit/phpunit": "~4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Add support for laravel 4.2 (~4.1 => >=4.1, <5.0-dev).
- Updated require-dev dependencies to depend on their current major version
- Bumped phpunit/phpunit to 4.0
