### PR TITLE
getTranslationModelNameDefault

### DIFF
--- a/Translatable/Translatable.php
+++ b/Translatable/Translatable.php
@@ -59,13 +59,13 @@ trait Translatable {
 
     public function getTranslationModelName()
     {
-        return $this->translationModel ?: $this->getTranslationModelNameDefault();
+       return $this->translationModel ?: $this->getTranslationModelNameDefault();
     }
 
     public function getTranslationModelNameDefault()
     {
-  		$config = App::make('config');
-  		return get_class($this) . $config->get('app.translation_model', 'Translation');
+        $config = App::make('config');
+        return get_class($this) . $config->get('app.translatable_suffix', 'Translation');
     }
 
     public function getRelationKey()


### PR DESCRIPTION
Make Translation Model Name readable from app config instead of fixed 'Translation'
