### PR TITLE
Locale fallback mode can be set per model

### DIFF
--- a/Translatable/Translatable.php
+++ b/Translatable/Translatable.php
@@ -30,7 +30,9 @@ trait Translatable {
         {
             $translation = $this->getTranslationByLocaleKey($locale);
         }
-        elseif ($withFallback && App::make('config')->has('app.fallback_locale'))
+        elseif ($withFallback
+            && App::make('config')->has('app.fallback_locale')
+            && $this->getTranslationByLocaleKey(App::make('config')->get('app.fallback_locale')))
         {
             $translation = $this->getTranslationByLocaleKey(App::make('config')->get('app.fallback_locale'));
         }


### PR DESCRIPTION
I was very happy to find this package!

As I started using it, I realized that I wanted a better way to default whether or not the fallback would be used rather than having to specify to use it every time I accessed the data.  This change would allow the model to decide whether or not to use the fallback mode.
