### PR TITLE
Allow locales like 'en-US'

### DIFF
--- a/Translatable/Translatable.php
+++ b/Translatable/Translatable.php
@@ -23,7 +23,7 @@ trait Translatable {
     }
 
     /**
-     * Returns only the language if the format locale is like 'en-US'
+     * Returns only the language if the format locale is like 'en-US' or 'en_US'
      */
     public function getLanguageLocale($locale)
     {


### PR DESCRIPTION
References bug: https://github.com/dimsav/laravel-translatable/issues/50

Allow use locales like en-US, es-ES

When save or get a register, gets only the first part of the locale, that references the language. When save we don't want save locales as en-US, because the language is en and the country is not necessary
