### PR TITLE
Don't specify Laravel versionnumber in general intro

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Laravel-Translatable
 [![License](https://poser.pugx.org/dimsav/laravel-translatable/license.svg)](https://packagist.org/packages/dimsav/laravel-translatable)
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/c105358a-3211-47e8-b662-94aa98d1eeee/mini.png)](https://insight.sensiolabs.com/projects/c105358a-3211-47e8-b662-94aa98d1eeee)
 
-This is a Laravel 4 package for translatable models. Its goal is to remove the complexity in retrieving and storing multilingual model instances. With this package you write less code, as the translations are being fetched/saved when you fetch/save your instance.
+This is a Laravel package for translatable models. Its goal is to remove the complexity in retrieving and storing multilingual model instances. With this package you write less code, as the translations are being fetched/saved when you fetch/save your instance.
 
 If you want to store translations of your models into the database, this package is for you.
 


### PR DESCRIPTION
Since the package supports both Laravel 4 and 5 you can omit the version number in the general intro