### PR TITLE
Add mutator/accessor translations

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -103,12 +103,18 @@ trait Translatable
 
     public function getAttribute($key)
     {
+        if (str_contains($key, ':')) {
+            list($key, $locale) = explode(':', $key);
+        } else {
+            $locale = App::getLocale();
+        }
+
         if ($this->isTranslationAttribute($key)) {
             if ($this->getTranslation() === null) {
                 return;
             }
 
-            return $this->getTranslation()->$key;
+            return $this->getTranslation($locale)->$key;
         }
 
         return parent::getAttribute($key);
@@ -116,8 +122,14 @@ trait Translatable
 
     public function setAttribute($key, $value)
     {
+        if (str_contains($key, ':')) {
+            list($key, $locale) = explode(':', $key);
+        } else {
+            $locale = App::getLocale();
+        }
+
         if (in_array($key, $this->translatedAttributes)) {
-            $this->getTranslationOrNew(App::getLocale())->$key = $value;
+            $this->getTranslationOrNew($locale)->$key = $value;
         } else {
             parent::setAttribute($key, $value);
         }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -86,6 +86,18 @@ class TranslatableTest extends TestsBase
     /**
      * @test
      */
+    public function it_returns_the_translation_with_accessor()
+    {
+        /** @var Country $country */
+        $country = Country::whereCode('gr')->first();
+
+        $this->assertEquals('Ελλάδα', $country->{'name:el'});
+        $this->assertEquals('Greece', $country->{'name:en'});
+    }
+
+    /**
+     * @test
+     */
     public function it_saves_translations()
     {
         $country = Country::whereCode('gr')->first();
@@ -95,6 +107,28 @@ class TranslatableTest extends TestsBase
 
         $country = Country::whereCode('gr')->first();
         $this->assertEquals('1234', $country->name);
+    }
+
+    /**
+     * @test
+     */
+    public function it_saves_translations_with_mutator()
+    {
+        $country = Country::whereCode('gr')->first();
+
+        $country->{'name:en'} = '1234';
+        $country->{'name:el'} = '5678';
+        $country->save();
+
+        $country = Country::whereCode('gr')->first();
+
+        $this->app->setLocale('en');
+        $translation = $country->translate();
+        $this->assertEquals('1234', $translation->name);
+
+        $this->app->setLocale('el');
+        $translation = $country->translate();
+        $this->assertEquals('5678', $translation->name);
     }
 
     /**


### PR DESCRIPTION
PR for #116
Make $country->{'name:en'} or $country['name:en'] synonym for $country->translate('en')->name

Easier to automate form building/submissions.