### PR TITLE
Add firstOrCreate function

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -163,6 +163,31 @@ trait Translatable
         return false;
     }
 
+    public static function firstOrCreate(array $attributes)
+    {
+        $instance = new static;
+        $original = $attributes;
+
+        foreach($instance->getLocales() as $locale) {
+            if (array_key_exists($locale, $attributes)) {
+                $locales[$locale] = array_pull($attributes, $locale);
+            }
+        }
+
+        if (! is_null($model = static::where($attributes)->first())) {
+            foreach ($locales as $locale => $value) {
+                if (! $model->hasTranslation($locale)) {
+                    $model->fill([$locale => $value]);
+                }
+            }
+            $model->save();
+
+            return $model;
+        }
+
+        return static::create($original);
+    }
+
     protected function getTranslationOrNew($locale)
     {
         if (($translation = $this->getTranslation($locale, false)) === null) {

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -482,4 +482,67 @@ class TranslatableTest extends TestsBase
         ]];
         $this->assertEquals($list, $country->listsTranslations('name')->get()->toArray());
     }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_model_with_newly_created_translations()
+    {
+        $data = [
+            'code' => 'be',
+            'en' => ['name' => 'Belgium'],
+            'fr' => ['name' => 'Belgique'],
+        ];
+
+        $country = Country::firstOrCreate($data);
+        $this->assertEquals('be', $country->code);
+        $this->assertEquals('Belgium', $country->translate('en')->name);
+        $this->assertEquals('Belgique', $country->translate('fr')->name);
+
+        $country = Country::whereCode('be')->first();
+        $this->assertEquals('Belgium', $country->translate('en')->name);
+        $this->assertEquals('Belgique', $country->translate('fr')->name);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_model_with_existing_translations()
+    {
+        $data = [
+            'code' => 'gr',
+            'en' => ['name' => 'Greece'],
+            'fr' => ['name' => 'Grèce'],
+        ];
+
+        $country = Country::firstOrCreate($data);
+        $this->assertEquals('gr', $country->code);
+        $this->assertEquals('Greece', $country->translate('en')->name);
+        $this->assertEquals('Grèce', $country->translate('fr')->name);
+
+        $country = Country::whereCode('gr')->first();
+        $this->assertEquals('Greece', $country->translate('en')->name);
+        $this->assertEquals('Grèce', $country->translate('fr')->name);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_model_with_existing_and_newly_created_translations()
+    {
+        $data = [
+            'code' => 'fr',
+            'en' => ['name' => 'France'],
+            'de' => ['name' => 'Frankrijk'],
+        ];
+
+        $country = Country::firstOrCreate($data);
+        $this->assertEquals('fr', $country->code);
+        $this->assertEquals('France', $country->translate('en')->name);
+        $this->assertEquals('Frankrijk', $country->translate('de')->name);
+
+        $country = Country::whereCode('fr')->first();
+        $this->assertEquals('France', $country->translate('en')->name);
+        $this->assertEquals('Frankrijk', $country->translate('de')->name);
+    }
 }


### PR DESCRIPTION
Extending Model::firstOrCreate($attributes) method:
```php
$attributes = [
    'id' => 1,
    'en' => [
         'name' => 'value',
    ],
    'fr' => [
        'name' => 'valeur',
    ]
];

$model = Model::firstOrCreate($attributes);
```

- If Model and translation(s) exists, it will simply return the Model with his respective translation(s).
- If Model exists but translation(s) does not exists, it will create all the missing translation(s) and return the Model with his newly created translation(s).
- If Model and translation(s) does not exists, it will create the Model and his translations and return the newly create Model with translation(s).