### PR TITLE
Update Translatable.php

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -111,7 +111,7 @@ trait Translatable
     /**
      * @return string
      */
-    public function getTranslationForeignKey() {
+    private function getTranslationForeignKey() {
         return $this->translationForeignKey ?: ($this->primaryKey !== 'id' ? $this->primaryKey : false);
     }
 

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -111,9 +111,16 @@ trait Translatable
     /**
      * @return string
      */
+    public function getTranslationForeignKey() {
+        return $this->translationForeignKey ?: ($this->primaryKey !== 'id' ? $this->primaryKey : false);
+    }
+
+    /**
+     * @return string
+     */
     public function getRelationKey()
     {
-        return $this->translationForeignKey ?: $this->getForeignKey();
+        return $this->getTranslationForeignKey() ?: $this->getForeignKey();
     }
 
     /**


### PR DESCRIPTION
Changed getRelationKey() method, and added getTranslationForeignKey() method so that when a custom primary key is used in the Model,  it is used by default as the foreign key in the translationtable.