### PR TITLE
Add locale provider

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -580,7 +580,13 @@ trait Translatable
      */
     protected function locale()
     {
-        return App::make('config')->get('translatable.locale')
+        $config = App::make('config');
+
+        if($config->get("translatable.locale_provider")) {
+            return App::make($config->get("translatable.locale_provider"))->locale();
+        }
+
+        return $config->get('translatable.locale')
             ?: App::make('translator')->getLocale();
     }
 }

--- a/src/config/translatable.php
+++ b/src/config/translatable.php
@@ -42,6 +42,19 @@ return [
     |
     */
     'locale' => null,
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Locale provider
+    |--------------------------------------------------------------------------
+    |
+    | The full path of a locale provider Class, responsible for returning
+    | the current locale value. This alternative is useful in some cms
+    | cases, where content locale and website locale can be different.
+    | The class must implement a public locale() method.
+    |
+    */
+    'locale_provider' => null,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The idea is to add a locale_provider config in order to be able to separate the
global locale and the Translatable locale, if needed.
Let's say you have a CMS, with an admin panel: you want
to manage locale for content apart from global website locale.