### PR TITLE
Fix call saving event

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -205,7 +205,7 @@ trait Translatable
                 // If $this->exists and not dirty, parent::save() skips saving and returns
                 // false. So we have to save the translations
                 if ($saved = $this->saveTranslations()) {
-                    $this->fireModelEvent('saved', false);
+                    $this->fireModelEvent('saved', true);
                 }
 
                 return $saved;


### PR DESCRIPTION
This fix will allow various associated events are fired to the Model that is using the Trait.

Currently, if I register two listeners for saving event, only the latter will be called