### PR TITLE
Undo unnecessary $translatedAttributes property

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,9 +129,8 @@ Schema::create('country_translations', function(Blueprint $table)
 class Country extends Eloquent {
     
     use \Dimsav\Translatable\Translatable;
-    
-    public $translatedAttributes = ['name'];
-    protected $fillable = ['code', 'name'];
+
+    protected $fillable = ['code'];
     
     /**
      * The relations to eager load on every query.
@@ -151,8 +150,6 @@ class CountryTranslation extends Eloquent {
 
 }
 ```
-
-The array `$translatedAttributes` contains the names of the fields being translated in the "Translation" model.
 
 ### Step 4: Configuration
 
@@ -283,18 +280,6 @@ Country::whereTranslationLike('name', '%Gree%')->first();
 ```
 
 ### Magic properties
-
-To use the magic properties, you have to define the property `$translatedAttributes` in your
- main model:
-
- ```php
- class Country extends Eloquent {
-
-     use \Dimsav\Translatable\Translatable;
-
-     public $translatedAttributes = ['name'];
- }
- ```
 
 ```php
 // Again we start by having a country instance

--- a/src/config/translatable.php
+++ b/src/config/translatable.php
@@ -91,18 +91,4 @@ return [
     */
     'locale_key' => 'locale',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Make translated attributes always fillable
-    |--------------------------------------------------------------------------
-    |
-    | If true, translatable automatically sets
-    | translated attributes as fillable.
-    |
-    | WARNING!
-    | Set this to true only if you understand the security risks.
-    |
-    */
-    'always_fillable' => false,
-
 ];


### PR DESCRIPTION
See https://github.com/dimsav/laravel-translatable/pull/184#issuecomment-170337684

I could not get the tests to work (check [here](https://github.com/Propaganistas/Laravel-Auth-Context/blob/master/tests/TestAuthContext.php#L51) for perhaps an easy database test setup?), so I didn't test out the code yet.