### PR TITLE
BUGFIX: Fixed a bug in locale fallback on toArray()

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -54,6 +54,7 @@ trait Translatable
      */
     public function getTranslation($locale = null, $withFallback = null)
     {
+        $configFallbackLocale = $this->getFallbackLocale($locale);
         $locale = $locale ?: $this->locale();
         $withFallback = $withFallback === null ? $this->useFallback() : $withFallback;
         $fallbackLocale = $this->getFallbackLocale($locale);
@@ -65,6 +66,11 @@ trait Translatable
             && $this->getTranslationByLocaleKey($fallbackLocale)
         ) {
             $translation = $this->getTranslationByLocaleKey($fallbackLocale);
+        } elseif($withFallback
+            && $fallbackLocale
+            && $this->getTranslationByLocaleKey($configFallbackLocale)
+        ) {
+               $translation = $this->getTranslationByLocaleKey($configFallbackLocale);
         } else {
             $translation = null;
         }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -59,23 +59,19 @@ trait Translatable
         $withFallback = $withFallback === null ? $this->useFallback() : $withFallback;
         $fallbackLocale = $this->getFallbackLocale($locale);
 
-        if ($this->getTranslationByLocaleKey($locale)) {
-            $translation = $this->getTranslationByLocaleKey($locale);
-        } elseif ($withFallback
-            && $fallbackLocale
-            && $this->getTranslationByLocaleKey($fallbackLocale)
-        ) {
-            $translation = $this->getTranslationByLocaleKey($fallbackLocale);
-        } elseif($withFallback
-            && $fallbackLocale
-            && $this->getTranslationByLocaleKey($configFallbackLocale)
-        ) {
-               $translation = $this->getTranslationByLocaleKey($configFallbackLocale);
-        } else {
-            $translation = null;
+        if ($translation = $this->getTranslationByLocaleKey($locale)) {
+            return $translation;
+        }
+        if ($withFallback && $fallbackLocale) {
+            if ($translation = $this->getTranslationByLocaleKey($fallbackLocale)) {
+                return $translation;
+            }
+            if ($translation = $this->getTranslationByLocaleKey($configFallbackLocale)) {
+                return $translation;
+            }
         }
 
-        return $translation;
+        return null;
     }
 
     /**

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -411,4 +411,19 @@ class TranslatableTest extends TestsBase
         $fries = Food::find(1);
         $this->assertSame('french fries', $fries->getTranslation('en-US')->name);
     }
+
+    public function test_to_array_and_fallback_with_country_based_locales_enabled()
+    {
+        $this->app->config->set('translatable.use_fallback', true);
+        $this->app->config->set('translatable.fallback_locale', 'fr');
+        $this->app->config->set('translatable.locales', ['en' => ['GB'], 'fr']);
+        $this->app->config->set('translatable.locale_separator', '-');
+        $data = [
+            'id' => 1,
+            'fr' => ['name' => 'frites'],
+        ];
+        Food::create($data);
+        $fritesArray = Food::find(1)->toArray();
+        $this->assertSame('frites', $fritesArray['name']);
+    }
 }


### PR DESCRIPTION
The bug occurs when you call toArray() on a model where a translation
does not exist for the current app locale and you have a translation
for the fallback locale set in the translatable.config

In this case you expect toArray() to merge the $translatedProperties
with the fallback translation, but this does not happen.

Added test to confirm bug is solved.

###### Sample translatable config setup
``` php

return [
'locales' => [
'nb' => [
,
],
'da' => [
'DK',
]
],
'locale_separator' => '_',
'locale' => null,
'use_fallback' => true,
'fallback_locale' => 'nb',
'translation_suffix' => 'Translation',
'locale_key' => 'locale',
'always_fillable' => false,

];

```

###### Matching php sample
``` php

// lets say we have a food model with a $translatedAttributes =
['name'];
Food::create([
'id' => 1,
'nb' => [
'name' => 'test'
]
]);

app()->setLocale('da_DK');

$food = Food::find(1)->toArray();

// Because our config has locale_fallback set to 'nb' we expect $food
to be:

[
'id' => 1,
'name' => 'test'
]

// However because of the bug $food is just:

[
'id' => 1,
]

```