### PR TITLE
Added notTranslatedIn scopes

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -459,6 +459,21 @@ trait Translatable
 
     /**
      * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string $locale
+     *
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function scopeNotTranslatedIn(Builder $query, $locale = null)
+    {
+        $locale = $locale ?: $this->locale();
+
+        return $query->whereDoesntHave('translations', function (Builder $q) use ($locale) {
+            $q->where($this->getLocaleKey(), '=', $locale);
+        });
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
      *
      * @return \Illuminate\Database\Eloquent\Builder|static
      */

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -21,6 +21,27 @@ class ScopesTest extends TestsBase
         $this->assertSame('Griechenland', $translatedCountries->first()->name);
     }
 
+    public function test_not_translated_in_scope_returns_only_not_translated_records_for_this_locale()
+    {
+        $notTranslatedCountries = Country::notTranslatedIn('en')->get();
+        $this->assertCount(2, $notTranslatedCountries);
+
+        foreach($notTranslatedCountries as $notTranslatedCountry) {
+            $this->assertFalse($notTranslatedCountry->hasTranslation('en'));
+        }
+    }
+
+    public function test_not_translated_in_scope_works_with_default_locale()
+    {
+        App::setLocale('en');
+        $notTranslatedCountries = Country::notTranslatedIn()->get();
+        $this->assertCount(2, $notTranslatedCountries);
+
+        foreach($notTranslatedCountries as $notTranslatedCountry) {
+            $this->assertFalse($notTranslatedCountry->hasTranslation('en'));
+        }
+    }
+
     public function test_translated_scope_returns_records_with_at_least_one_translation()
     {
         $translatedCountries = Country::translated()->get();


### PR DESCRIPTION
Added a scope (`notTranslatedIn`) for fetching by those who doesn't have a specific translation.

Useful for creating a view to translate content and filtering by missing translations.