### PR TITLE
Filling multiple translations on update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 vendor/
 composer.lock
-.idea/
 coverage/

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ If you want to store translations of your models into the database, this package
   echo $greece->translate('fr')->name; // Grèce
 ```
 
+
 ## Tutorial
 
 Check the tutorial about laravel-translatable in laravel-news: [*How To Add Multilingual Support to Eloquent*](https://laravel-news.com/2015/09/how-to-add-multilingual-support-to-eloquent/)
@@ -146,8 +147,15 @@ class Country extends Eloquent {
 // models/CountryTranslation.php
 class CountryTranslation extends Eloquent {
 
+    use CompositeKeys;
+
     public $timestamps = false;
     protected $fillable = ['name'];
+
+    protected $primaryKey = [
+        'id',
+        'locale'
+    ];
 
 }
 ```

--- a/src/Translatable/CompositeKeys.php
+++ b/src/Translatable/CompositeKeys.php
@@ -1,0 +1,45 @@
+<?php namespace Dimsav\Translatable;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait CompositeKeys
+{
+    /**
+     * Set the keys for a save update query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function setKeysForSaveQuery(Builder $query)
+    {
+        $keys = $this->getKeyName();
+        if (!is_array($keys)) {
+            return parent::setKeysForSaveQuery($query);
+        }
+
+        foreach ($keys as $keyName) {
+            $query->where($keyName, '=', $this->getKeyForSaveQuery($keyName));
+        }
+
+        return $query;
+    }
+
+    /**
+     * Get the primary key value for a save query.
+     *
+     * @param mixed $keyName
+     * @return mixed
+     */
+    protected function getKeyForSaveQuery($keyName = null)
+    {
+        if (is_null($keyName)) {
+            $keyName = $this->getKeyName();
+        }
+
+        if (isset($this->original[$keyName])) {
+            return $this->original[$keyName];
+        }
+
+        return $this->getAttribute($keyName);
+    }
+}

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -163,7 +163,7 @@ trait Translatable
             $locale = $this->locale();
         }
 
-        if ($this->isTranslationAttribute($key)) {
+        if ($this->isTranslated && $this->isTranslationAttribute($key)) {
             if ($this->getTranslation($locale) === null) {
                 return;
             }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -612,7 +612,7 @@ trait Translatable
         return App::make('config')->get('translatable.locale')
             ?: App::make('translator')->getLocale();
     }
-    
+
     /**
      * Inner join with the translation table
      *
@@ -624,15 +624,17 @@ trait Translatable
     {
         // models
         $instance = new static;
-        $translationModel = new $instance->translationModel();
+
+        $translationModelName = $instance->getTranslationModelName();
+        $translationModel = new $translationModelName();
 
         // locale
         if (is_null($locale)) {
             $locale = $instance->locale();
         }
 
-        return $query->join($translationModel->getTable() . ' as t', 't.' . $instance->translationForeignKey, '=', $instance->getTable() . '.' . $instance->getKeyName())
-            ->where($instance->localeKey, $locale);
+        return $query->join($translationModel->getTable() . ' as t', 't.' . $instance->getRelationKey(), '=', $instance->getTable() . '.' . $instance->getKeyName())
+            ->where($instance->getLocaleKey(), $locale);
     }
     
     /**

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -162,7 +162,7 @@ trait Translatable
 
         if ($this->isTranslationAttribute($key)) {
             if ($this->getTranslation($locale) === null) {
-                return;
+                return parent::getAttribute($key);
             }
 
             return $this->getTranslation($locale)->$key;

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -419,7 +419,6 @@ class TranslatableTest extends TestsBase
 
         /** @var Country $country */
         $country = Country::JoinTranslation()->first();
-
         $this->assertEquals('Ελλάδα', $country->name);
 
         $queries = DB::getQueryLog();

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -411,4 +411,18 @@ class TranslatableTest extends TestsBase
         $fries = Food::find(1);
         $this->assertSame('french fries', $fries->getTranslation('en-US')->name);
     }
+
+    public function test_it_returns_the_translation_with_inner_join()
+    {
+        DB::enableQueryLog();
+        $this->app->setLocale('el');
+
+        /** @var Country $country */
+        $country = Country::JoinTranslation()->first();
+
+        $this->assertEquals('Ελλάδα', $country->name);
+
+        $queries = DB::getQueryLog();
+        $this->assertEquals(1, count($queries), 'You have with innerjoin more than one query');
+    }
 }


### PR DESCRIPTION
Hi @dimsav 
i use the function `filling multiple translations`. It works really great on create process. But if i have a array and i want it update like this: `$entry->update($values);` it fails.

It creates wrong update query:
```php
"query" => "update "cnc_products_lang" set "name" = ?, "description" = ? where "product_id" = ?"
    "bindings" => array:3 [
      0 => "EN-JEANS"
      1 => ""
      2 => "1"
    ]
```

After this fix it woulds great.
```php
    "query" => "update "cnc_products_lang" set "name" = ?, "description" = ? where "product_id" = ? and "locate" = ?"
    "bindings" => array:4 [
      0 => "ES-JEANS"
      1 => ""
      2 => "1"
      3 => "es"
    ]
```