### PR TITLE
Filling multiple translations on update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,7 @@ class CountryTranslation extends Eloquent {
 
     public $timestamps = false;
     protected $fillable = ['name'];
+    public $incrementing = false;
 
     protected $primaryKey = [
         'id',

--- a/readme.md
+++ b/readme.md
@@ -146,8 +146,15 @@ class Country extends Eloquent {
 // models/CountryTranslation.php
 class CountryTranslation extends Eloquent {
 
+    use CompositeKeys;
+
     public $timestamps = false;
     protected $fillable = ['name'];
+
+    protected $primaryKey = [
+        'id',
+        'locale'
+    ];
 
 }
 ```

--- a/src/Translatable/CompositeKeys.php
+++ b/src/Translatable/CompositeKeys.php
@@ -1,0 +1,45 @@
+<?php namespace Dimsav\Translatable;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait CompositeKeys
+{
+    /**
+     * Set the keys for a save update query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function setKeysForSaveQuery(Builder $query)
+    {
+        $keys = $this->getKeyName();
+        if (!is_array($keys)) {
+            return parent::setKeysForSaveQuery($query);
+        }
+
+        foreach ($keys as $keyName) {
+            $query->where($keyName, '=', $this->getKeyForSaveQuery($keyName));
+        }
+
+        return $query;
+    }
+
+    /**
+     * Get the primary key value for a save query.
+     *
+     * @param mixed $keyName
+     * @return mixed
+     */
+    protected function getKeyForSaveQuery($keyName = null)
+    {
+        if (is_null($keyName)) {
+            $keyName = $this->getKeyName();
+        }
+
+        if (isset($this->original[$keyName])) {
+            return $this->original[$keyName];
+        }
+
+        return $this->getAttribute($keyName);
+    }
+}

--- a/src/Translatable/CompositeKeys.php
+++ b/src/Translatable/CompositeKeys.php
@@ -1,4 +1,6 @@
-<?php namespace Dimsav\Translatable;
+<?php
+
+namespace Dimsav\Translatable;
 
 use Illuminate\Database\Eloquent\Builder;
 
@@ -7,7 +9,8 @@ trait CompositeKeys
     /**
      * Set the keys for a save update query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     *
      * @return \Illuminate\Database\Eloquent\Builder
      */
     protected function setKeysForSaveQuery(Builder $query)
@@ -28,6 +31,7 @@ trait CompositeKeys
      * Get the primary key value for a save query.
      *
      * @param mixed $keyName
+     *
      * @return mixed
      */
     protected function getKeyForSaveQuery($keyName = null)


### PR DESCRIPTION
Hi @dimsav 
i use the function `filling multiple translations`. It works really great on create process. But if i have a array and i want it update like this: `$entry->update($values);` it fails.

It creates wrong update query:
```php
"query" => "update "cnc_products_lang" set "name" = ?, "description" = ? where "product_id" = ?"
    "bindings" => array:3 [
      0 => "EN-JEANS"
      1 => ""
      2 => "1"
    ]
```

After this fix it create a right query.
```php
    "query" => "update "cnc_products_lang" set "name" = ?, "description" = ? where "product_id" = ? and "locate" = ?"
    "bindings" => array:4 [
      0 => "ES-JEANS"
      1 => ""
      2 => "1"
      3 => "es"
    ]
```