### PR TITLE
Fix issue when trying to fetch a translation with a country based locale

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -56,7 +56,7 @@ trait Translatable
      */
     public function getTranslation($locale = null, $withFallback = null)
     {
-        $configFallbackLocale = $this->getFallbackLocale($locale);
+        $configFallbackLocale = $this->getFallbackLocale();
         $locale = $locale ?: $this->locale();
         $withFallback = $withFallback === null ? $this->useFallback() : $withFallback;
         $fallbackLocale = $this->getFallbackLocale($locale);

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -403,7 +403,7 @@ class TranslatableTest extends TestsBase
         $fries = Food::find(1);
         $this->assertSame('french fries', $fries->getTranslation('en-US')->name);
     }
-    
+
     public function test_fallback_for_country_based_locales_with_no_base_locale()
     {
         $this->app->config->set('translatable.use_fallback', true);

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -403,6 +403,22 @@ class TranslatableTest extends TestsBase
         $fries = Food::find(1);
         $this->assertSame('french fries', $fries->getTranslation('en-US')->name);
     }
+    
+    public function test_fallback_for_country_based_locales_with_no_base_locale()
+    {
+        $this->app->config->set('translatable.use_fallback', true);
+        $this->app->config->set('translatable.fallback_locale', 'en');
+        $this->app->config->set('translatable.locales', ['pt' => ['PT', 'BR'], 'en']);
+        $this->app->config->set('translatable.locale_separator', '-');
+        $data = [
+            'id' => 1,
+            'en' => ['name' => 'chips'],
+            'pt-PT' => ['name' => 'batatas fritas'],
+        ];
+        Food::create($data);
+        $fries = Food::find(1);
+        $this->assertSame('chips', $fries->getTranslation('pt-BR')->name);
+    }
 
     public function test_to_array_and_fallback_with_country_based_locales_enabled()
     {


### PR DESCRIPTION
Fix issue when trying to fetch a translation with a country based (e.g. 'pt-PT') and the only translation available is for the fallback locale.

Cover the scenario where the configured fallback locale is 'en', you are trying to fetch a translation for 'pt-PT' but the model only has a translation to 'en'. As it was before the code would attempt to fetch a translation for 'pt' twice instead of trying 'pt' first and then use the configured fallback locale.