### PR TITLE
A model can have a default locale for translations

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -11,6 +11,8 @@ use Dimsav\Translatable\Exception\LocalesNotDefinedException;
 
 trait Translatable
 {
+    protected $defaultLocale;
+    
     /**
      * Alias for getTranslation().
      *
@@ -620,8 +622,36 @@ trait Translatable
      */
     protected function locale()
     {
+        if ($this->defaultLocale) {
+            return $this->defaultLocale;    
+        }
+        
         return app()->make('config')->get('translatable.locale')
             ?: app()->make('translator')->getLocale();
+    }
+    
+    /**
+     * Set the default locale on the model.
+     *
+     * @param $locale
+     *
+     * @return $this
+     */
+    public function setDefaultLocale($locale)
+    {
+        $this->defaultLocale = $locale;
+
+        return $this;
+    }
+
+    /**
+     * Get the default locale on the model.
+     *
+     * @return mixed
+     */
+    public function getDefaultLocale()
+    {
+        return $this->defaultLocale;
     }
 
     /**

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -12,7 +12,7 @@ use Dimsav\Translatable\Exception\LocalesNotDefinedException;
 trait Translatable
 {
     protected $defaultLocale;
-    
+
     /**
      * Alias for getTranslation().
      *
@@ -623,13 +623,13 @@ trait Translatable
     protected function locale()
     {
         if ($this->defaultLocale) {
-            return $this->defaultLocale;    
+            return $this->defaultLocale;
         }
-        
+
         return app()->make('config')->get('translatable.locale')
             ?: app()->make('translator')->getLocale();
     }
-    
+
     /**
      * Set the default locale on the model.
      *

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -509,4 +509,24 @@ class TranslatableTest extends TestsBase
         $this->assertEquals($country->translate('en')->name, 'Turkey');
         $this->assertEquals($country->translate('de')->name, 'Türkei');
     }
+
+    public function test_it_uses_the_default_locale_from_the_model()
+    {
+        $country = new Country();
+        $country->fill([
+            'code'    => 'tn',
+            'name:en' => 'Tunisia',
+            'name:fr' => 'Tunisie',
+        ]);
+        $this->assertEquals($country->name, 'Tunisia');
+        $country->setDefaultLocale('fr');
+        $this->assertEquals($country->name, 'Tunisie');
+
+        $country->setDefaultLocale(null);
+        $country->save();
+        $country = Country::whereCode('tn')->first();
+        $this->assertEquals($country->name, 'Tunisia');
+        $country->setDefaultLocale('fr');
+        $this->assertEquals($country->name, 'Tunisie');
+    }
 }


### PR DESCRIPTION
This will allow to return the translation in the desired locale, by calling the attribute on the model without the need of changing the application locale using App::setLocale();
