### PR TITLE
Added support to not load translations automatically when using toArray

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -588,6 +588,12 @@ trait Translatable
     {
         $attributes = parent::toArray();
 
+        // do not add translations when the relation is not loaded (user decides when the translations is loaded)
+        // automatic load is default behaviour
+        if (!app()->make('config')->get("translatable.load_translations_to_array", true) && !$this->relationLoaded("translations")) {
+            return $attributes;
+        }
+
         $hiddenAttributes = $this->getHidden();
 
         foreach ($this->translatedAttributes as $field) {

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -590,7 +590,7 @@ trait Translatable
 
         // do not add translations when the relation is not loaded (user decides when the translations is loaded)
         // automatic load is default behaviour
-        if (!app()->make('config')->get("translatable.load_translations_to_array", true) && !$this->relationLoaded("translations")) {
+        if (! app()->make('config')->get('translatable.load_translations_to_array', true) && ! $this->relationLoaded('translations')) {
             return $attributes;
         }
 

--- a/src/config/translatable.php
+++ b/src/config/translatable.php
@@ -91,4 +91,13 @@ return [
     */
     'locale_key' => 'locale',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Make translated attributes always fillable
+    |--------------------------------------------------------------------------
+    |
+    | When running toArray (json etc) will load the translations even if not loaded with relation.
+    |
+    */
+    'load_translations_to_array' => true
 ];

--- a/src/config/translatable.php
+++ b/src/config/translatable.php
@@ -99,5 +99,5 @@ return [
     | When running toArray (json etc) will load the translations even if not loaded with relation.
     |
     */
-    'load_translations_to_array' => true
+    'load_translations_to_array' => true,
 ];


### PR DESCRIPTION
The model forces to load translations even when I don’t want to load it (this is done when using toArray which loops supported keys and forces them to be loaded).

The previous functionality is preserved. Manageable via config
