### PR TITLE
Support fill() for multi languages similar to setAttribute()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -392,6 +392,12 @@ Thanks to the community a few packages have been written to make usage of Transl
  
 ## FAQ
 
+#### Running package unit test
+
+Change database user/password configuration [in the code](https://github.com/dimsav/laravel-translatable/tree/master/tests/TestsBase.php#L11).
+
+Run `phpunit` to run default tests
+
 #### I need some example code!
 
 Examples for all the package features can be found [in the code](https://github.com/dimsav/laravel-translatable/tree/master/tests/models) used for the [tests](https://github.com/dimsav/laravel-translatable/tree/master/tests).

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -478,4 +478,31 @@ class TranslatableTest extends TestsBase
         $country = Country::whereCode('gr')->with('translations')->first();
         $this->assertSame($count, count($country->translations));
     }
+
+    public function test_fill_with_translation_key()
+    {
+        $country = new Country();
+        $country->fill([
+            'code' => 'gr',
+            'name:en' => 'Greece FILL',
+            'name:de' => 'Griechenland FILL',
+        ]);
+
+        $this->assertEquals($country->translate('en')->name, 'Greece FILL');
+        $this->assertEquals($country->translate('de')->name, 'Griechenland FILL');
+    }
+
+    public function test_fill_with_translation_key_save_success()
+    {
+        $country = Country::whereCode('gr')->first();
+        $country->fill([
+            'name:en' => 'Greece FILL',
+            'name:de' => 'Griechenland FILL',
+        ]);
+        $country->save();
+
+        $country = Country::whereCode('gr')->first();
+        $this->assertEquals($country->translate('en')->name, 'Greece FILL');
+        $this->assertEquals($country->translate('de')->name, 'Griechenland FILL');
+    }
 }

--- a/tests/models/Person.php
+++ b/tests/models/Person.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 class Person extends Eloquent
 {
     protected $table = 'people';
+    public $fillable = ['name'];
 
     use Translatable;
 


### PR DESCRIPTION
Support fillable multi language with various type of format

```
[
    'LANG' => [
    	'FIELD' => 'VALUE',
    ]
]
```

And

```
[
    'FIELD:LANG' => 'VALUE',
]
```

Both way is totally the same.

```
$country = Country::whereCode('gr')->first();
$country->fill([
    'name:en' => 'Greece',
    'name:de' => 'Griechenlan',
]);
$country->save();
```