### PR TITLE
toArray() performance

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 ```
 $country->fill(['name:en' => 'Belgium']);
 ```  
+- Added config to skip translations in toArray() for better performance when needed. #315
 
 ### v. 6.0.1
 

--- a/readme.md
+++ b/readme.md
@@ -178,6 +178,10 @@ With this command, initialize the configuration and modify the created file, loc
 
 ## Configuration
 
+### The config file
+
+You can see the options for further customization in the [config file](src/config/translatable.php).
+
 ### The translation model
 
 The convention used to define the class of the translation model is to append the keyword `Translation`.

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -660,12 +660,9 @@ trait Translatable
 
     /**
      * @return bool
-     *
      */
     private function toArrayAlwaysLoadsTranslations()
     {
         return app()->make('config')->get('translatable.to_array_always_loads_translations', true);
     }
-
-
 }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -586,6 +586,12 @@ trait Translatable
     {
         $attributes = parent::toArray();
 
+        if ($this->relationLoaded('translations') || $this->toArrayAlwaysLoadsTranslations()) {
+            // continue
+        } else {
+            return $attributes;
+        }
+
         $hiddenAttributes = $this->getHidden();
 
         foreach ($this->translatedAttributes as $field) {
@@ -651,4 +657,15 @@ trait Translatable
 
         return [$key, $this->locale()];
     }
+
+    /**
+     * @return bool
+     *
+     */
+    private function toArrayAlwaysLoadsTranslations()
+    {
+        return app()->make('config')->get('translatable.to_array_always_loads_translations', true);
+    }
+
+
 }

--- a/src/config/translatable.php
+++ b/src/config/translatable.php
@@ -91,4 +91,14 @@ return [
     */
     'locale_key' => 'locale',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Always load translations when converting to array
+    |--------------------------------------------------------------------------
+    | Setting this to false will have a performance improvement but will
+    | not return the translations when using toArray(), unless the
+    | translations relationship is already loaded.
+    |
+     */
+    'to_array_always_loads_translations' => true,
 ];

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -435,6 +435,20 @@ class TranslatableTest extends TestsBase
         $this->assertSame('frites', $fritesArray['name']);
     }
 
+    public function test_it_skips_translations_in_to_array_when_config_is_set()
+    {
+        $this->app->config->set('translatable.to_array_always_loads_translations', false);
+        $greece = Country::whereCode('gr')->first()->toArray();
+        $this->assertFalse(isset($greece['name']));
+    }
+
+    public function test_it_returns_translations_in_to_array_when_config_is_set_but_translations_are_loaded()
+    {
+        $this->app->config->set('translatable.to_array_always_loads_translations', false);
+        $greece = Country::whereCode('gr')->with('translations')->first()->toArray();
+        $this->assertTrue(isset($greece['name']));
+    }
+
     public function test_it_should_mutate_the_translated_attribute_if_a_mutator_is_set_on_model()
     {
         $person = new Person(['name' => 'john doe']);


### PR DESCRIPTION
- Skip translations in toArray() when configured unless translations already loaded.