### PR TITLE
Add translatedAttributes and translationForeignKey attributes getters

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -97,6 +97,14 @@ trait Translatable
     }
 
     /**
+     * @return array
+     */
+    public function getTranslatedAttributes()
+    {
+        return $this->translatedAttributes ?: [];
+    }
+
+    /**
      * @return string
      */
     public function getTranslationModelName()
@@ -339,7 +347,7 @@ trait Translatable
      */
     public function isTranslationAttribute($key)
     {
-        return in_array($key, $this->translatedAttributes);
+        return in_array($key, $this->getTranslatedAttributes());
     }
 
     /**
@@ -596,7 +604,7 @@ trait Translatable
 
         $hiddenAttributes = $this->getHidden();
 
-        foreach ($this->translatedAttributes as $field) {
+        foreach ($this->getTranslatedAttributes() as $field) {
             if (in_array($field, $hiddenAttributes)) {
                 continue;
             }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -123,12 +123,20 @@ trait Translatable
     }
 
     /**
+     * @return string|null
+     */
+    public function getTranslationForeignKey()
+    {
+        return $this->translationForeignKey ?: null;
+    }
+
+    /**
      * @return string
      */
     public function getRelationKey()
     {
-        if ($this->translationForeignKey) {
-            $key = $this->translationForeignKey;
+        if ($this->getTranslationForeignKey()) {
+            $key = $this->getTranslationForeignKey();
         } elseif ($this->primaryKey !== 'id') {
             $key = $this->primaryKey;
         } else {


### PR DESCRIPTION
This fix makes possible to dynamically override trait attributes in custom child traits or models.

Because currently only `translationModel` and `localeKey` attributes could be overrided by `getTranslationModelName` and `getLocaleKey` respectively.

Custom trait usage example:
```
<?php

namespace App\Util\Database\Models;

use Dimsav\Translatable\Translatable;

trait CustomTranslatable
{
    use Translatable;

    public function getTranslatedAttributes()
    {
        // custom logic goes here
    }

    public function getTranslationForeignKey()
    {
        // custom logic goes here
    }
}
```