### PR TITLE
added getTranslationsArray() method

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -608,6 +608,21 @@ trait Translatable
 
         return $attributes;
     }
+    
+    /**
+     * @return array
+     */
+    public function getTranslationsArray() {
+        $translations = [];
+
+        foreach($this->translations as $translation) {
+            foreach($this->translatedAttributes as $attr) {
+                $translations[$translation->{$this->getLocaleKey()}][$attr] = $translation->{$attr};
+            }
+        }
+
+        return $translations;
+    }
 
     /**
      * @return string

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -608,16 +608,15 @@ trait Translatable
 
         return $attributes;
     }
-
+    
     /**
      * @return array
      */
-    public function getTranslationsArray()
-	{
+    public function getTranslationsArray() {
         $translations = [];
 
-        foreach ($this->translations as $translation) {
-            foreach ($this->translatedAttributes as $attr) {
+        foreach($this->translations as $translation) {
+            foreach($this->translatedAttributes as $attr) {
                 $translations[$translation->{$this->getLocaleKey()}][$attr] = $translation->{$attr};
             }
         }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -608,15 +608,16 @@ trait Translatable
 
         return $attributes;
     }
-    
+
     /**
      * @return array
      */
-    public function getTranslationsArray() {
+    public function getTranslationsArray()
+    {
         $translations = [];
 
-        foreach($this->translations as $translation) {
-            foreach($this->translatedAttributes as $attr) {
+        foreach ($this->translations as $translation) {
+            foreach ($this->translatedAttributes as $attr) {
                 $translations[$translation->{$this->getLocaleKey()}][$attr] = $translation->{$attr};
             }
         }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -608,15 +608,16 @@ trait Translatable
 
         return $attributes;
     }
-    
+
     /**
      * @return array
      */
-    public function getTranslationsArray() {
+    public function getTranslationsArray()
+	{
         $translations = [];
 
-        foreach($this->translations as $translation) {
-            foreach($this->translatedAttributes as $attr) {
+        foreach ($this->translations as $translation) {
+            foreach ($this->translatedAttributes as $attr) {
                 $translations[$translation->{$this->getLocaleKey()}][$attr] = $translation->{$attr};
             }
         }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -529,4 +529,23 @@ class TranslatableTest extends TestsBase
         $country->setDefaultLocale('fr');
         $this->assertEquals($country->name, 'Tunisie');
     }
+	
+    public function test_retriving_translatable_array() {
+        $country = new Country();
+        $country->fill([
+            'code'    => 'tn',
+            'name:en' => 'Tunisia',
+            'name:fr' => 'Tunisie',
+        ]);
+        
+        $testArr = array();
+        
+        foreach($country->translations as $translation) {
+            foreach($country->translatedAttributes as $attr) {
+                $testArr[$translation->locale][$attr] = $translation->{$attr};
+            }
+        }
+        
+        $this->assertEquals($testArr, $country->getTranslationsArray());
+    }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -530,23 +530,22 @@ class TranslatableTest extends TestsBase
         $this->assertEquals($country->name, 'Tunisie');
     }
 	
-    public function test_retriving_translatable_array()
-	{
+    public function test_retriving_translatable_array() {
         $country = new Country();
         $country->fill([
             'code'    => 'tn',
             'name:en' => 'Tunisia',
             'name:fr' => 'Tunisie',
         ]);
-
+        
         $testArr = array();
-
-        foreach ($country->translations as $translation) {
-            foreach ($country->translatedAttributes as $attr) {
+        
+        foreach($country->translations as $translation) {
+            foreach($country->translatedAttributes as $attr) {
                 $testArr[$translation->locale][$attr] = $translation->{$attr};
             }
         }
-
+        
         $this->assertEquals($testArr, $country->getTranslationsArray());
     }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -530,22 +530,23 @@ class TranslatableTest extends TestsBase
         $this->assertEquals($country->name, 'Tunisie');
     }
 	
-    public function test_retriving_translatable_array() {
+    public function test_retriving_translatable_array()
+	{
         $country = new Country();
         $country->fill([
             'code'    => 'tn',
             'name:en' => 'Tunisia',
             'name:fr' => 'Tunisie',
         ]);
-        
+
         $testArr = array();
-        
-        foreach($country->translations as $translation) {
-            foreach($country->translatedAttributes as $attr) {
+
+        foreach ($country->translations as $translation) {
+            foreach ($country->translatedAttributes as $attr) {
                 $testArr[$translation->locale][$attr] = $translation->{$attr};
             }
         }
-        
+
         $this->assertEquals($testArr, $country->getTranslationsArray());
     }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -529,23 +529,24 @@ class TranslatableTest extends TestsBase
         $country->setDefaultLocale('fr');
         $this->assertEquals($country->name, 'Tunisie');
     }
-	
-    public function test_retriving_translatable_array() {
+
+    public function test_retriving_translatable_array()
+    {
         $country = new Country();
         $country->fill([
             'code'    => 'tn',
             'name:en' => 'Tunisia',
             'name:fr' => 'Tunisie',
         ]);
-        
-        $testArr = array();
-        
-        foreach($country->translations as $translation) {
-            foreach($country->translatedAttributes as $attr) {
+
+        $testArr = [];
+
+        foreach ($country->translations as $translation) {
+            foreach ($country->translatedAttributes as $attr) {
                 $testArr[$translation->locale][$attr] = $translation->{$attr};
             }
         }
-        
+
         $this->assertEquals($testArr, $country->getTranslationsArray());
     }
 }


### PR DESCRIPTION
According to issue #273, it would be great to have a way to retrieve translations in the same structure such as for saving (like `fill()` method). For example I have a view with a form for updating some of my translatable records. My form fields named `en[title]`, `en[description]`, `es[title]` and so on. It is easy to store these data (via `create()` or `fill()` methods), and they can be easily passed to the view via `$input->old()` method. But there is no way to retrive and pass translations data to the view directly from translatable model, because their stucture is different. What do you think about it?