### PR TITLE
Fixed: different results using fill() method with same data

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -258,7 +258,7 @@ trait Translatable
                 unset($attributes[$key]);
             } else {
                 list($attribute, $locale) = $this->getAttributeAndLocale($key);
-                if ($this->isTranslationAttribute($attribute)) {
+                if ($this->isTranslationAttribute($attribute) and $this->isKeyALocale($locale)) {
                     $this->getTranslationOrNew($locale)->fill([$attribute => $values]);
                     unset($attributes[$key]);
                 }
@@ -607,22 +607,6 @@ trait Translatable
         }
 
         return $attributes;
-    }
-
-    /**
-     * @return array
-     */
-    public function getTranslationsArray()
-    {
-        $translations = [];
-
-        foreach ($this->translations as $translation) {
-            foreach ($this->translatedAttributes as $attr) {
-                $translations[$translation->{$this->getLocaleKey()}][$attr] = $translation->{$attr};
-            }
-        }
-
-        return $translations;
     }
 
     /**

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -608,6 +608,21 @@ trait Translatable
 
         return $attributes;
     }
+    
+    /**
+     * @return array
+     */
+    public function getTranslationsArray() {
+        $translations = [];
+
+        foreach($this->translations as $translation) {
+            foreach($this->translatedAttributes as $attr) {
+                $translations[$translation->{$this->getLocaleKey()}][$attr] = $translation->{$attr};
+            }
+        }
+
+        return $translations;
+    }
 
     /**
      * @return string

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -608,16 +608,15 @@ trait Translatable
 
         return $attributes;
     }
-
+    
     /**
      * @return array
      */
-    public function getTranslationsArray()
-	{
+    public function getTranslationsArray() {
         $translations = [];
 
-        foreach ($this->translations as $translation) {
-            foreach ($this->translatedAttributes as $attr) {
+        foreach($this->translations as $translation) {
+            foreach($this->translatedAttributes as $attr) {
                 $translations[$translation->{$this->getLocaleKey()}][$attr] = $translation->{$attr};
             }
         }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -608,15 +608,16 @@ trait Translatable
 
         return $attributes;
     }
-    
+
     /**
      * @return array
      */
-    public function getTranslationsArray() {
+    public function getTranslationsArray()
+    {
         $translations = [];
 
-        foreach($this->translations as $translation) {
-            foreach($this->translatedAttributes as $attr) {
+        foreach ($this->translations as $translation) {
+            foreach ($this->translatedAttributes as $attr) {
                 $translations[$translation->{$this->getLocaleKey()}][$attr] = $translation->{$attr};
             }
         }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -608,15 +608,16 @@ trait Translatable
 
         return $attributes;
     }
-    
+
     /**
      * @return array
      */
-    public function getTranslationsArray() {
+    public function getTranslationsArray()
+	{
         $translations = [];
 
-        foreach($this->translations as $translation) {
-            foreach($this->translatedAttributes as $attr) {
+        foreach ($this->translations as $translation) {
+            foreach ($this->translatedAttributes as $attr) {
                 $translations[$translation->{$this->getLocaleKey()}][$attr] = $translation->{$attr};
             }
         }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -530,23 +530,55 @@ class TranslatableTest extends TestsBase
         $this->assertEquals($country->name, 'Tunisie');
     }
 
-    public function test_retriving_translatable_array()
+    public function test_fill_when_locale_key_unknown()
     {
+        config(['translatable.locales' => ['en']]);
+
         $country = new Country();
         $country->fill([
-            'code'    => 'tn',
-            'name:en' => 'Tunisia',
-            'name:fr' => 'Tunisie',
+            'code' => 'ua',
+            'en'   => ['name' => 'Ukraine'],
+            'ua'   => ['name' => 'Україна'], // "ua" is unknown, so must be ignored
         ]);
 
-        $testArr = [];
+        $modelTranslations = [];
 
         foreach ($country->translations as $translation) {
             foreach ($country->translatedAttributes as $attr) {
-                $testArr[$translation->locale][$attr] = $translation->{$attr};
+                $modelTranslations[$translation->locale][$attr] = $translation->{$attr};
             }
         }
 
-        $this->assertEquals($testArr, $country->getTranslationsArray());
+        $expectedTranslations = [
+            'en' => ['name' => 'Ukraine']
+        ];
+
+        $this->assertEquals($modelTranslations, $expectedTranslations);
+    }
+
+    public function test_fill_with_translation_key_when_locale_key_unknown()
+    {
+        config(['translatable.locales' => ['en']]);
+
+        $country = new Country();
+        $country->fill([
+            'code'    => 'ua',
+            'name:en' => 'Ukraine',
+            'name:ua' => 'Україна', // "ua" is unknown, so must be ignored
+        ]);
+
+        $modelTranslations = [];
+
+        foreach ($country->translations as $translation) {
+            foreach ($country->translatedAttributes as $attr) {
+                $modelTranslations[$translation->locale][$attr] = $translation->{$attr};
+            }
+        }
+
+        $expectedTranslations = [
+            'en' => ['name' => 'Ukraine']
+        ];
+
+        $this->assertEquals($modelTranslations, $expectedTranslations);
     }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -529,4 +529,23 @@ class TranslatableTest extends TestsBase
         $country->setDefaultLocale('fr');
         $this->assertEquals($country->name, 'Tunisie');
     }
+	
+    public function test_retriving_translatable_array() {
+        $country = new Country();
+        $country->fill([
+            'code'    => 'tn',
+            'name:en' => 'Tunisia',
+            'name:fr' => 'Tunisie',
+        ]);
+        
+        $testArr = array();
+        
+        foreach($country->translations as $translation) {
+            foreach($country->translatedAttributes as $attr) {
+                $testArr[$translation->locale][$attr] = $translation->{$attr};
+            }
+        }
+        
+        $this->assertEquals($testArr, $country->getTranslationsArray());
+    }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -550,7 +550,7 @@ class TranslatableTest extends TestsBase
         }
 
         $expectedTranslations = [
-            'en' => ['name' => 'Ukraine']
+            'en' => ['name' => 'Ukraine'],
         ];
 
         $this->assertEquals($modelTranslations, $expectedTranslations);
@@ -576,7 +576,7 @@ class TranslatableTest extends TestsBase
         }
 
         $expectedTranslations = [
-            'en' => ['name' => 'Ukraine']
+            'en' => ['name' => 'Ukraine'],
         ];
 
         $this->assertEquals($modelTranslations, $expectedTranslations);

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -530,23 +530,22 @@ class TranslatableTest extends TestsBase
         $this->assertEquals($country->name, 'Tunisie');
     }
 	
-    public function test_retriving_translatable_array()
-	{
+    public function test_retriving_translatable_array() {
         $country = new Country();
         $country->fill([
             'code'    => 'tn',
             'name:en' => 'Tunisia',
             'name:fr' => 'Tunisie',
         ]);
-
+        
         $testArr = array();
-
-        foreach ($country->translations as $translation) {
-            foreach ($country->translatedAttributes as $attr) {
+        
+        foreach($country->translations as $translation) {
+            foreach($country->translatedAttributes as $attr) {
                 $testArr[$translation->locale][$attr] = $translation->{$attr};
             }
         }
-
+        
         $this->assertEquals($testArr, $country->getTranslationsArray());
     }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -530,22 +530,23 @@ class TranslatableTest extends TestsBase
         $this->assertEquals($country->name, 'Tunisie');
     }
 	
-    public function test_retriving_translatable_array() {
+    public function test_retriving_translatable_array()
+	{
         $country = new Country();
         $country->fill([
             'code'    => 'tn',
             'name:en' => 'Tunisia',
             'name:fr' => 'Tunisie',
         ]);
-        
+
         $testArr = array();
-        
-        foreach($country->translations as $translation) {
-            foreach($country->translatedAttributes as $attr) {
+
+        foreach ($country->translations as $translation) {
+            foreach ($country->translatedAttributes as $attr) {
                 $testArr[$translation->locale][$attr] = $translation->{$attr};
             }
         }
-        
+
         $this->assertEquals($testArr, $country->getTranslationsArray());
     }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -529,23 +529,24 @@ class TranslatableTest extends TestsBase
         $country->setDefaultLocale('fr');
         $this->assertEquals($country->name, 'Tunisie');
     }
-	
-    public function test_retriving_translatable_array() {
+
+    public function test_retriving_translatable_array()
+    {
         $country = new Country();
         $country->fill([
             'code'    => 'tn',
             'name:en' => 'Tunisia',
             'name:fr' => 'Tunisie',
         ]);
-        
-        $testArr = array();
-        
-        foreach($country->translations as $translation) {
-            foreach($country->translatedAttributes as $attr) {
+
+        $testArr = [];
+
+        foreach ($country->translations as $translation) {
+            foreach ($country->translatedAttributes as $attr) {
                 $testArr[$translation->locale][$attr] = $translation->{$attr};
             }
         }
-        
+
         $this->assertEquals($testArr, $country->getTranslationsArray());
     }
 }


### PR DESCRIPTION
Hello, guys! While I was writing tests for #347, I noticed that `fill()` method produces different results depending on how we pass data to it. Here what I mean (example from readme.md):
```php
// First, using the locale as array key.
$greece = $country->fill([
    'en'  => ['name' => 'Greece'],
    'fr'  => ['name' => 'Grèce'],
]);

// The second way is to use the following syntax.  
$greece = $country->fill([
    'name:en' => 'Greece',
    'name:fr' => 'Grèce',
]);
```
The difference appears when one (or many) of passed languages is not exists in `translatable.locales` config array. Unknown languages must be ignored, and they are ignored in example 1, but not in second example. There are some tests to illustrate this issue.