### PR TITLE
Delete via model instead of QueryBuilder

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -733,7 +733,7 @@ trait Translatable
         foreach ($translations as $translation) {
             $translation->delete();
         }
-        
+
         // we need to manually "reload" the collection built from the relationship
         // otherwise $this->translations()->get() would NOT be the same as $this->translations
         $this->load('translations');

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -725,12 +725,15 @@ trait Translatable
     public function deleteTranslations($locales = null)
     {
         if ($locales === null) {
-            $this->translations()->delete();
+            $translations = $this->translations()->get();
         } else {
             $locales = (array) $locales;
-            $this->translations()->whereIn($this->getLocaleKey(), $locales)->delete();
+            $translations = $this->translations()->whereIn($this->getLocaleKey(), $locales)->get();
         }
-
+        foreach ($translations as $translation) {
+            $translation->delete();
+        }
+        
         // we need to manually "reload" the collection built from the relationship
         // otherwise $this->translations()->get() would NOT be the same as $this->translations
         $this->load('translations');


### PR DESCRIPTION
I use Translatable along with a model logging package that uses events to log changes. Deleting translations did not log (deleted event didn't fire) because they were deleted directly from the QueryBuilder, not model instances.