### PR TITLE
Use 'attributesToArray()' instead of 'toArray()'

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -678,7 +678,7 @@ trait Translatable
     {
         $attributes = parent::attributesToArray();
 
-        if (!$this->relationLoaded('translations') && !$this->toArrayAlwaysLoadsTranslations()) {
+        if (! $this->relationLoaded('translations') && ! $this->toArrayAlwaysLoadsTranslations()) {
             return $attributes;
         }
 

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -678,9 +678,7 @@ trait Translatable
     {
         $attributes = parent::attributesToArray();
 
-        if ($this->relationLoaded('translations') || $this->toArrayAlwaysLoadsTranslations()) {
-            // continue
-        } else {
+        if (!$this->relationLoaded('translations') && !$this->toArrayAlwaysLoadsTranslations()) {
             return $attributes;
         }
 

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -674,9 +674,9 @@ trait Translatable
     /**
      * @return array
      */
-    public function toArray()
+    public function attributesToArray()
     {
-        $attributes = parent::toArray();
+        $attributes = parent::attributesToArray();
 
         if ($this->relationLoaded('translations') || $this->toArrayAlwaysLoadsTranslations()) {
             // continue

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -166,14 +166,12 @@ trait Translatable
      */
     private function getAttributeOrFallback($locale, $attribute)
     {
-        $value = $this->getTranslation($locale)->$attribute;
-
         $usePropertyFallback = $this->useFallback() && $this->usePropertyFallback();
-        if (empty($value) && $usePropertyFallback) {
+        if (!$this->hasTranslation($locale) && $usePropertyFallback) {
             return $this->getTranslation($this->getFallbackLocale(), true)->$attribute;
         }
 
-        return $value;
+        return $this->getTranslation($locale)->$attribute;
     }
 
     /**


### PR DESCRIPTION
The Translatabe Trait implemented the `toArray()` method which includes relationships. I think the intention here was to override `attributesToArray()` instead. It is called within the [original implementation of `toArray`](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Database/Eloquent/Model.php#L894)  anyway.

The problem with the current implementation is that the translated attributes are discarded when calling `attributesToArray()` later...