### PR TITLE
Added `getDirtyWithTranslations` method

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -243,9 +243,12 @@ trait Translatable
 
                 return $saved;
             }
+        } elseif (parent::save($options)) {
+            // We save the translations only if the instance is saved in the database.
+            return $this->saveTranslations();
         }
 
-        return $this->saveTranslations() && parent::save($options);
+        return false;
     }
 
     /**

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -459,7 +459,7 @@ trait Translatable
         unset($dirty[$this->getLocaleKey()]);
 
         if ($notEmpty = ! empty($dirty)) {
-            $locale   = $translation->{$this->getLocaleKey()};
+            $locale = $translation->{$this->getLocaleKey()};
             $original = [];
 
             foreach ($dirty as $key => $value) {

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -487,8 +487,6 @@ trait Translatable
      */
     public function getDirtyWithTranslations()
     {
-        $dirty = $this->getDirty();
-
         if ($translations = config(static::class.'.'.$this->getKey())) {
             foreach ($translations as $locale => $transDirty) {
                 foreach ($transDirty['dirty'] as $key => $value) {
@@ -500,14 +498,10 @@ trait Translatable
                 foreach ($transDirty['original'] as $key => $value) {
                     $this->original[$key.':'.$locale] = $value;
                 }
-
-                unset($transDirty['dirty'], $transDirty['original']);
-
-                $dirty += $transDirty;
             }
         }
 
-        return $dirty;
+        return $this->getDirty();
     }
 
     /**

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -462,7 +462,6 @@ trait Translatable
         unset($dirty[$this->getLocaleKey()]);
 
         if ($notEmpty = ! empty($dirty)) {
-            $locale = $translation->{$this->getLocaleKey()};
             $original = [];
 
             foreach ($dirty as $key => $value) {
@@ -470,7 +469,7 @@ trait Translatable
             }
 
             config([
-                static::class.'.'.$this->getKey().'.'.$locale => [
+                static::class.'.'.$this->getKey().'.'.$translation->{$this->getLocaleKey()} => [
                     'dirty'    => $dirty,
                     'original' => $original,
                 ],

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -2,11 +2,11 @@
 
 namespace Dimsav\Translatable;
 
-use Dimsav\Translatable\Exception\LocalesNotDefinedException;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Dimsav\Translatable\Exception\LocalesNotDefinedException;
 
 trait Translatable
 {
@@ -470,7 +470,7 @@ trait Translatable
                 static::class.'.'.$this->getKey().'.'.$locale => [
                     'dirty'    => $dirty,
                     'original' => $original,
-                ]
+                ],
             ]);
         }
 


### PR DESCRIPTION
#373 
I could only add another method `getDirtyWithTranslations`, but I had to make `$this->saveTranslations()` before the `parent::save($options)`. So, it works only on update.