### PR TITLE
Upgraded dependencies to support Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.4.*"
+        "illuminate/support": "5.5.*"
     },
     "require-dev": {
-        "orchestra/testbench": "3.4.*",
-        "phpunit/phpunit": "~5.7"
+        "orchestra/testbench": "3.5.*",
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I've run the unit tests locally and everything looks good. This fork is working on a Laravel 5.5 project without any noticeable problems.