### PR TITLE
Don't use fallback if record exists and the value is null

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -166,14 +166,12 @@ trait Translatable
      */
     private function getAttributeOrFallback($locale, $attribute)
     {
-        $value = $this->getTranslation($locale)->$attribute;
-
         $usePropertyFallback = $this->useFallback() && $this->usePropertyFallback();
-        if (empty($value) && $usePropertyFallback) {
+        if (!$this->hasTranslation($locale) && $usePropertyFallback) {
             return $this->getTranslation($this->getFallbackLocale(), true)->$attribute;
         }
 
-        return $value;
+        return $this->getTranslation($locale)->$attribute;
     }
 
     /**

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -166,12 +166,14 @@ trait Translatable
      */
     private function getAttributeOrFallback($locale, $attribute)
     {
+        $value = $this->getTranslation($locale)->$attribute;
+
         $usePropertyFallback = $this->useFallback() && $this->usePropertyFallback();
-        if (!$this->hasTranslation($locale) && $usePropertyFallback) {
-            return $this->getTranslation($this->getFallbackLocale(), true)->$attribute;
+        if (empty($value) && $usePropertyFallback && $fallback = $this->getTranslation($this->getFallbackLocale(), true)) {
+            return $fallback->$attribute;
         }
 
-        return $this->getTranslation($locale)->$attribute;
+        return $value;
     }
 
     /**


### PR DESCRIPTION
When using a model with different translatable attributes, e.g. a required name & nullable description without a fallback dataset this change will return null instead of throwing a _'Trying to get property of non object'_ exception.