### PR TITLE
Solving the issue of empty attribute values

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -187,7 +187,7 @@ trait Translatable
 
         if ($this->isTranslationAttribute($attribute)) {
             if ($this->getTranslation($locale) === null) {
-                return null;
+                return $this->getAttributeValue($attribute);
             }
 
             // If the given $attribute has a mutator, we push it to $attributes and then call getAttributeValue


### PR DESCRIPTION
When the `model_translations` table is empty or the related key from the `models` table is not assigned yet, i.e not translated, the original attribute value is returned as `null` so there is no text! This is a proposed solution for that issue.