### PR TITLE
Fix withTranslation query scope performance issues and fallback for country-based locales

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -578,11 +578,13 @@ trait Translatable
     {
         $query->with([
             'translations' => function (Relation $query) {
-                $query->where($this->getTranslationsTable().'.'.$this->getLocaleKey(), $this->locale());
-
                 if ($this->useFallback()) {
-                    return $query->orWhere($this->getTranslationsTable().'.'.$this->getLocaleKey(), $this->getFallbackLocale());
+                    $locale = $this->locale();
+                    $countryFallbackLocale = $this->getFallbackLocale($locale); // e.g. de-DE => de
+                    $locales = array_unique([$locale, $countryFallbackLocale, $this->getFallbackLocale()]);
+                    return $query->whereIn($this->getTranslationsTable() . '.' . $this->getLocaleKey(), $locales);
                 }
+                $query->where($this->getTranslationsTable().'.'.$this->getLocaleKey(), $this->locale());
             },
         ]);
     }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -582,9 +582,9 @@ trait Translatable
                     $locale = $this->locale();
                     $countryFallbackLocale = $this->getFallbackLocale($locale); // e.g. de-DE => de
                     $locales = array_unique([$locale, $countryFallbackLocale, $this->getFallbackLocale()]);
-                    return $query->whereIn($this->getTranslationsTable() . '.' . $this->getLocaleKey(), $locales);
+                    return $query->whereIn($this->getTranslationsTable().'.'.$this->getLocaleKey(), $locales);
                 }
-                $query->where($this->getTranslationsTable().'.'.$this->getLocaleKey(), $this->locale());
+                return $query->where($this->getTranslationsTable().'.'.$this->getLocaleKey(), $this->locale());
             },
         ]);
     }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -582,8 +582,10 @@ trait Translatable
                     $locale = $this->locale();
                     $countryFallbackLocale = $this->getFallbackLocale($locale); // e.g. de-DE => de
                     $locales = array_unique([$locale, $countryFallbackLocale, $this->getFallbackLocale()]);
+
                     return $query->whereIn($this->getTranslationsTable().'.'.$this->getLocaleKey(), $locales);
                 }
+
                 return $query->where($this->getTranslationsTable().'.'.$this->getLocaleKey(), $this->locale());
             },
         ]);

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Dimsav\Translatable\Test\Model\Vegetable;
 use Dimsav\Translatable\Test\Model\Country;
+use Dimsav\Translatable\Test\Model\Vegetable;
 
 class ScopesTest extends TestsBase
 {
@@ -103,9 +103,9 @@ class ScopesTest extends TestsBase
         App::setLocale('de-CH');
         $result = Vegetable::withTranslation()->find(1)->toArray();
         $expectedTranslations = [
-            ['name' => 'zucchini', 'locale' => 'en',],
-            ['name' => 'Zucchini', 'locale' => 'de',],
-            ['name' => 'Zucchetti', 'locale' => 'de-CH',],
+            ['name' => 'zucchini', 'locale' => 'en'],
+            ['name' => 'Zucchini', 'locale' => 'de'],
+            ['name' => 'Zucchetti', 'locale' => 'de-CH'],
         ];
         $this->assertArraySubset($expectedTranslations, $result['translations']);
     }

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -93,7 +93,8 @@ class ScopesTest extends TestsBase
         $this->assertSame('Griechenland', $loadedTranslations[1]['name']);
     }
 
-    public function test_scope_withTranslation_with_country_based_fallback() {
+    public function test_scope_withTranslation_with_country_based_fallback()
+    {
         App::make('config')->set('translatable.fallback_locale', 'en');
         App::make('config')->set('translatable.use_fallback', true);
         App::setLocale('en-GB');

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Dimsav\Translatable\Test\Model\Vegetable;
 use Dimsav\Translatable\Test\Model\Country;
 
 class ScopesTest extends TestsBase
@@ -90,6 +91,23 @@ class ScopesTest extends TestsBase
         $this->assertCount(2, $loadedTranslations);
         $this->assertSame('Greece', $loadedTranslations[0]['name']);
         $this->assertSame('Griechenland', $loadedTranslations[1]['name']);
+    }
+
+    public function test_scope_withTranslation_with_country_based_fallback() {
+        App::make('config')->set('translatable.fallback_locale', 'en');
+        App::make('config')->set('translatable.use_fallback', true);
+        App::setLocale('en-GB');
+        $result = Vegetable::withTranslation()->find(1)->toArray();
+        $this->assertSame('courgette', $result['name']);
+
+        App::setLocale('de-CH');
+        $result = Vegetable::withTranslation()->find(1)->toArray();
+        $expectedTranslations = [
+            ['name' => 'zucchini', 'locale' => 'en',],
+            ['name' => 'Zucchini', 'locale' => 'de',],
+            ['name' => 'Zucchetti', 'locale' => 'de-CH',],
+        ];
+        $this->assertArraySubset($expectedTranslations, $result['translations']);
     }
 
     public function test_whereTranslation_filters_by_translation()

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -53,7 +53,7 @@ class ScopesTest extends TestsBase
             'id'   => '1',
             'name' => 'Griechenland',
         ]];
-        $this->assertEquals($list, Country::listsTranslations('name')->get()->toArray());
+        $this->assertArraySubset($list, Country::listsTranslations('name')->get()->toArray());
     }
 
     public function test_lists_of_translated_fields_with_fallback()
@@ -69,7 +69,7 @@ class ScopesTest extends TestsBase
             'id'   => '2',
             'name' => 'France',
         ]];
-        $this->assertEquals($list, $country->listsTranslations('name')->get()->toArray());
+        $this->assertArraySubset($list, $country->listsTranslations('name')->get()->toArray());
     }
 
     public function test_scope_withTranslation_without_fallback()

--- a/tests/TestsBase.php
+++ b/tests/TestsBase.php
@@ -123,7 +123,8 @@ class TestsBase extends TestCase
             'collation' => 'utf8_unicode_ci',
             'strict' => false,
         ]);
-        $app['config']->set('translatable.locales', ['el', 'en', 'fr', 'de', 'id']);
+        $locales = ['el', 'en', 'fr', 'de', 'id', 'en-GB', 'en-US', 'de-DE', 'de-CH'];
+        $app['config']->set('translatable.locales', $locales);
     }
 
     protected function getPackageAliases($app)

--- a/tests/models/Vegetable.php
+++ b/tests/models/Vegetable.php
@@ -9,7 +9,9 @@ class Vegetable extends Eloquent
 {
     use Translatable;
 
-    protected $primaryKey = 'vegetable_identity';
+    protected $primaryKey = 'identity';
+
+    protected $translationForeignKey = 'vegetable_identity';
 
     public $translatedAttributes = ['name'];
 }

--- a/tests/seeds/AddFreshSeeds.php
+++ b/tests/seeds/AddFreshSeeds.php
@@ -2,8 +2,10 @@
 
 use Dimsav\Translatable\Test\Model\City;
 use Dimsav\Translatable\Test\Model\Country;
+use Dimsav\Translatable\Test\Model\Vegetable;
 use Dimsav\Translatable\Test\Model\CityTranslation;
 use Dimsav\Translatable\Test\Model\CountryTranslation;
+use Dimsav\Translatable\Test\Model\VegetableTranslation;
 
 class AddFreshSeeds
 {
@@ -42,6 +44,25 @@ class AddFreshSeeds
         ];
 
         $this->createCityTranslations($cityTranslations);
+
+        $vegetables = [
+            ['vegetable_identity' => 1],
+            ['vegetable_identity' => 2],
+        ];
+
+        $this->createVegetables($vegetables);
+
+        $vegetableTranslations = [
+            ['vegetable_identity' => 1, 'locale' => 'en',    'name' => 'zucchini'],
+            ['vegetable_identity' => 1, 'locale' => 'en-GB', 'name' => 'courgette'],
+            ['vegetable_identity' => 1, 'locale' => 'en-US', 'name' => 'zucchini'],
+            ['vegetable_identity' => 1, 'locale' => 'de',    'name' => 'Zucchini'],
+            ['vegetable_identity' => 1, 'locale' => 'de-CH', 'name' => 'Zucchetti'],
+            ['vegetable_identity' => 2, 'locale' => 'en',    'name' => 'aubergine'],
+            ['vegetable_identity' => 2, 'locale' => 'en-US', 'name' => 'eggplant'],
+        ];
+
+        $this->createVegetableTranslations($vegetableTranslations);
     }
 
     private function createCountries($countries)
@@ -80,6 +101,26 @@ class AddFreshSeeds
         foreach ($translations as $data) {
             $translation = new CityTranslation();
             $translation->city_id = $data['city_id'];
+            $translation->locale = $data['locale'];
+            $translation->name = $data['name'];
+            $translation->save();
+        }
+    }
+
+    private function createVegetables($vegetables)
+    {
+        foreach ($vegetables as $vegetable) {
+            $vegetable = new Vegetable();
+            $vegetable->identity = $vegetable['identity'];
+            $vegetable->save();
+        }
+    }
+
+    private function createVegetableTranslations($translations)
+    {
+        foreach ($translations as $data) {
+            $translation = new VegetableTranslation();
+            $translation->vegetable_identity = $data['vegetable_identity'];
             $translation->locale = $data['locale'];
             $translation->name = $data['name'];
             $translation->save();


### PR DESCRIPTION
This PR fixes two separate but related issues with the `withTranslation` query scope.

#### Slow performance due to over-fetching 

As reported in #241, the generated SQL has an error that will cause it to incorrectly fetch all of the translations for the default language:

```
SELECT * FROM `xxx_translations
WHERE `xxx_translations`.`product_id` IN ('59') AND
       `xxx_translations`.`locale` = 'fr' OR `xxx_translations`.`locale` = 'en'`
      ^ parenthesis is missing here                                ... and here ^
```

This can be fixed by wrapping the `OR` clauses in parentheses (by using the adequate query builder methods), or simply by using a `WHERE IN` statement. I chose the latter option.

---
#### Language fallback is skipped when using a country-based locale

When using country-based fallbacks, the language fallback wasn't appended to the SQL request. So, to build on the current [example scenario](https://github.com/dimsav/laravel-translatable#country-based-fallback) in the README, instead of querying for `es-MX`, `es`, `en`, the query only looked for `es-MX` and `en`, and skipping the language altogether.

Also, since this feature didn't seem to have any tests, I have added started adding a few.