### PR TITLE
Avoid fetching attribute on non-object on empty translation when fallback translation is not available

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -165,8 +165,12 @@ trait Translatable
         $value = $this->getTranslation($locale)->$attribute;
 
         $usePropertyFallback = $this->useFallback() && $this->usePropertyFallback();
-        if (empty($value) && $usePropertyFallback) {
-            return $this->getTranslation($this->getFallbackLocale(), true)->$attribute;
+        if (
+            empty($value) &&
+            $usePropertyFallback &&
+            ($fallback = $this->getTranslation($this->getFallbackLocale(), true))
+        ) {
+            return $fallback->$attribute;
         }
 
         return $value;

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -635,6 +635,26 @@ class TranslatableTest extends TestsBase
         $this->assertEquals('Tunisia', $country->name);
     }
 
+    public function test_it_always_uses_value_when_fallback_not_available()
+    {
+        App::make('config')->set('translatable.fallback_locale', 'it');
+        App::make('config')->set('translatable.use_fallback', true);
+
+        $country = new Country();
+        $country->fill([
+            'code' => 'gr',
+            'en' => ['name' => ''],
+            'de' => ['name' => 'Griechenland'],
+        ]);
+
+        // verify translated attributed is correctly returned when empty (non-existing fallback is ignored)
+        $this->app->setLocale('en');
+        $this->assertEquals('', $country->getAttribute('name'));
+
+        $this->app->setLocale('de');
+        $this->assertEquals('Griechenland', $country->getAttribute('name'));
+    }
+
     public function test_translation_with_multiconnection()
     {
         // Add country & translation in second db


### PR DESCRIPTION
* avoid fetching attribute on non-object on empty translation when fallback translation is not available
* added phpunit testing with empty translation and without a fallback translation
Completes https://github.com/dimsav/laravel-translatable/pull/396