### PR TITLE
Move tests autoload classmap to dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
     "autoload": {
         "psr-4": {
             "Dimsav\\Translatable\\": "src/Translatable/"
-        },
+        }
+    },
+    "autoload-dev": {
         "classmap": [
             "tests"
         ]


### PR DESCRIPTION
This avoids having things like:

```
'TestCoreModelExtension' => $vendorDir . '/dimsav/laravel-translatable/tests/TestCoreModelExtension.php',
'TestsBase' => $vendorDir . '/dimsav/laravel-translatable/tests/TestsBase.php',
'TranslatableTest' => $vendorDir . '/dimsav/laravel-translatable/tests/TranslatableTest.php',
```

Show up on your production autoload_classmap file when installed with `--no-dev`