### PR TITLE
added orderByTranslation scope

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -695,7 +695,7 @@ trait Translatable
             ->where($translationTable.'.'.$localeKey, $this->locale());
         })
         ->orderBy($translationTable.'.'.$key, $sortmethod)
-        ->select($translationTable.'.*', $table.'.*')
+        ->select($table.'.*')
         ->with('translations');
     }
 

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -675,6 +675,31 @@ trait Translatable
     }
 
     /**
+     * This scope sorts results by the given translation field.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string                                $key
+     * @param string                                $sortmethod
+     *
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function scopeOrderByTranslation(Builder $query, $key, $sortmethod = 'asc')
+    {
+        $translationTable = $this->getTranslationsTable();
+        $localeKey = $this->getLocaleKey();
+        $table = $this->getTable();
+        $keyName = $this->getKeyName();
+
+        return $query->join($translationTable, function($join) use ($translationTable, $localeKey, $table, $keyName) {
+            $join->on($translationTable.'.'.$this->getRelationKey(), '=', $table.'.'.$keyName)
+            ->where($translationTable.'.'.$localeKey, $this->locale());
+        })
+        ->orderBy($translationTable.'.'.$key, $sortmethod)
+        ->select($translationTable.'.*', $table.'.*')
+        ->with('translations');
+    }
+
+    /**
      * @return array
      */
     public function attributesToArray()

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -694,7 +694,7 @@ trait Translatable
         $keyName = $this->getKeyName();
 
         return $query
-            ->join($translationTable, function(Builder $join) use ($translationTable, $localeKey, $table, $keyName) {
+            ->join($translationTable, function (Builder $join) use ($translationTable, $localeKey, $table, $keyName) {
                 $join
                     ->on($translationTable.'.'.$this->getRelationKey(), '=', $table.'.'.$keyName)
                     ->where($translationTable.'.'.$localeKey, $this->locale());

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -693,8 +693,7 @@ trait Translatable
         return $query->join($translationTable, function($join) use ($translationTable, $localeKey, $table, $keyName) {
             $join->on($translationTable.'.'.$this->getRelationKey(), '=', $table.'.'.$keyName)
             ->where($translationTable.'.'.$localeKey, $this->locale());
-        })
-        ->orderBy($translationTable.'.'.$key, $sortmethod)
+        })->orderBy($translationTable.'.'.$key, $sortmethod)
         ->select($table.'.*')
         ->with('translations');
     }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -690,12 +690,15 @@ trait Translatable
         $table = $this->getTable();
         $keyName = $this->getKeyName();
 
-        return $query->join($translationTable, function(Builder $join) use ($translationTable, $localeKey, $table, $keyName) {
-            $join->on($translationTable.'.'.$this->getRelationKey(), '=', $table.'.'.$keyName)
-            ->where($translationTable.'.'.$localeKey, $this->locale());
-        })->orderBy($translationTable.'.'.$key, $sortmethod)
-        ->select($table.'.*')
-        ->with('translations');
+        return $query
+            ->join($translationTable, function(Builder $join) use ($translationTable, $localeKey, $table, $keyName) {
+                $join
+                    ->on($translationTable.'.'.$this->getRelationKey(), '=', $table.'.'.$keyName)
+                    ->where($translationTable.'.'.$localeKey, $this->locale());
+            })
+            ->orderBy($translationTable.'.'.$key, $sortmethod)
+            ->select($table.'.*')
+            ->with('translations');
     }
 
     /**

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -690,7 +690,7 @@ trait Translatable
         $table = $this->getTable();
         $keyName = $this->getKeyName();
 
-        return $query->join($translationTable, function($join) use ($translationTable, $localeKey, $table, $keyName) {
+        return $query->join($translationTable, function(Builder $join) use ($translationTable, $localeKey, $table, $keyName) {
             $join->on($translationTable.'.'.$this->getRelationKey(), '=', $table.'.'.$keyName)
             ->where($translationTable.'.'.$localeKey, $this->locale());
         })->orderBy($translationTable.'.'.$key, $sortmethod)

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -165,4 +165,16 @@ class ScopesTest extends TestsBase
         $this->assertSame(1, $result->count());
         $this->assertSame('gr', $result->first()->code);
     }
+
+    public function test_orderByTranslation_sorts_by_key_asc()
+    {
+        $result = Country::orderByTranslation('name')->get();
+        $this->assertSame(2, $result->first()->id);
+    }
+
+    public function test_orderByTranslation_sorts_by_key_desc()
+    {
+        $result = Country::orderByTranslation('name', 'desc')->get();
+        $this->assertSame(1, $result->first()->id);
+    }
 }


### PR DESCRIPTION
I made a new scope to order results by translation fields.

```
Countries::orderByTranslation('name')->get();
```
will order the results based on the `name` attribute inside the translation table. 

```
Countries::orderByTranslation('name', 'desc')->get();
```
will do the same but in descending order