### PR TITLE
fire saving event in every case

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -242,6 +242,10 @@ trait Translatable
             } else {
                 // If $this->exists and not dirty, parent::save() skips saving and returns
                 // false. So we have to save the translations
+                if ($this->fireModelEvent('saving') === false) {
+                    return false;
+                }
+                
                 if ($saved = $this->saveTranslations()) {
                     $this->fireModelEvent('saved', false);
                     $this->fireModelEvent('updated', false);


### PR DESCRIPTION
solves #456

The normal laravel `save` method fires `saving` in every case - independent of dirty or anything else. This shouldn't be changed.