### PR TITLE
remove deprecated styleci linting

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,8 +2,6 @@ preset: laravel
 
 risky: true
 
-linting: true
-
 disabled:
   - no_useless_return
   - simplified_null_return


### PR DESCRIPTION
https://styleci.readme.io/docs/change-log#section-14042018-april-fixer-updates
> Finally, the long deprecated "linting" config option has now been removed.