### PR TITLE
Fix return type

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -260,7 +260,7 @@ trait Translatable
     /**
      * @param string $locale
      *
-     * @return \Illuminate\Database\Eloquent\Model|null
+     * @return \Illuminate\Database\Eloquent\Model
      */
     protected function getTranslationOrNew($locale)
     {


### PR DESCRIPTION
During review of #108 I recognized that the doc-tag of getTranslationOrNew() is wrong. It returns a model instance in every case.