### PR TITLE
Change autoload translations behavior on runtime

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -462,8 +462,16 @@ What applies for the fallback of the locales using the `en-MX` format?
 Let's say our fallback locale is `en`. Now, when we try to fetch from the database the translation for the 
 locale `es-MX` but it doesn't exist,  we won't get as fallback the translation for `en`. Translatable will use as a 
 fallback `es` (the first part of `es-MX`) and only if nothing is found, the translation for `en` is returned.
+
+### Translation Autoloading
+
+If the `toArray()` method is called it's possible to autoload all translations. To control this feature the package comes with a config value `to_array_always_loads_translations` and three static methods in the trait:
+
+* `enableAutoloadTranslations()` - forces to load all translations
+* `disableAutoloadTranslations()` - disables autoload and returns parent attributes
+* `defaultAutoloadTranslations()` - does not change the default behavior logic (*default*)
  
-#### Add ons
+## Add ons
 
 Thanks to the community a few packages have been written to make usage of Translatable easier when working with forms:
 

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -10,7 +10,7 @@ use Dimsav\Translatable\Exception\LocalesNotDefinedException;
 
 trait Translatable
 {
-    protected static $autoloadTranslations = true;
+    protected static $autoloadTranslations = null;
 
     protected $defaultLocale;
 
@@ -684,8 +684,8 @@ trait Translatable
         $attributes = parent::attributesToArray();
 
         if (
-            (! $this->relationLoaded('translations') && ! $this->toArrayAlwaysLoadsTranslations())
-            || !self::$autoloadTranslations
+            (! $this->relationLoaded('translations') && ! $this->toArrayAlwaysLoadsTranslations() && is_null(self::$autoloadTranslations))
+            || self::$autoloadTranslations === false
         ) {
             return $attributes;
         }
@@ -813,6 +813,10 @@ trait Translatable
 
     public static function enableAutoloadTranslations() {
         self::$autoloadTranslations = true;
+    }
+
+    public static function defaultAutoloadTranslations() {
+        self::$autoloadTranslations = null;
     }
 
     public static function disableAutoloadTranslations() {

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -811,15 +811,18 @@ trait Translatable
         return config('translatable.to_array_always_loads_translations', true);
     }
 
-    public static function enableAutoloadTranslations() {
+    public static function enableAutoloadTranslations()
+    {
         self::$autoloadTranslations = true;
     }
 
-    public static function defaultAutoloadTranslations() {
+    public static function defaultAutoloadTranslations()
+    {
         self::$autoloadTranslations = null;
     }
 
-    public static function disableAutoloadTranslations() {
+    public static function disableAutoloadTranslations()
+    {
         self::$autoloadTranslations = false;
     }
 }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -10,6 +10,8 @@ use Dimsav\Translatable\Exception\LocalesNotDefinedException;
 
 trait Translatable
 {
+    protected static $autoloadTranslations = true;
+
     protected $defaultLocale;
 
     /**
@@ -681,7 +683,10 @@ trait Translatable
     {
         $attributes = parent::attributesToArray();
 
-        if (! $this->relationLoaded('translations') && ! $this->toArrayAlwaysLoadsTranslations()) {
+        if (
+            (! $this->relationLoaded('translations') && ! $this->toArrayAlwaysLoadsTranslations())
+            || !self::$autoloadTranslations
+        ) {
             return $attributes;
         }
 
@@ -804,5 +809,13 @@ trait Translatable
     private function toArrayAlwaysLoadsTranslations()
     {
         return config('translatable.to_array_always_loads_translations', true);
+    }
+
+    public static function enableAutoloadTranslations() {
+        self::$autoloadTranslations = true;
+    }
+
+    public static function disableAutoloadTranslations() {
+        self::$autoloadTranslations = false;
     }
 }

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -76,6 +76,20 @@ class ScopesTest extends TestsBase
         $this->assertArraySubset($list, $country->listsTranslations('name')->get()->toArray());
     }
 
+    public function test_lists_of_translated_fields_disable_autoload_translations()
+    {
+        App::setLocale('de');
+        App::make('config')->set('translatable.to_array_always_loads_translations', true);
+
+        $list = [[
+            'id'   => 1,
+            'name' => 'Griechenland',
+        ]];
+        Country::disableAutoloadTranslations();
+        $this->assertEquals($list, Country::listsTranslations('name')->get()->toArray());
+        Country::defaultAutoloadTranslations();
+    }
+
     public function test_scope_withTranslation_without_fallback()
     {
         $result = Country::withTranslation()->first();

--- a/tests/TestsBase.php
+++ b/tests/TestsBase.php
@@ -135,9 +135,9 @@ class TestsBase extends TestCase
     protected function enableQueryCounter()
     {
         $that = $this;
-        DB::listen(function ($query) use ($that) {
+        DB::listen(function (\Illuminate\Database\Events\QueryExecuted $query) use ($that) {
             $that->queriesCount++;
-//             echo("\n--- Query {$that->queriesCount}--- {$this->beautifyQuery($this->insertBindingsIntoQuery($query->sql, $this->formatBindingsForSqlInjection($query->bindings)))}\n");
+//             echo("\n--- Query {$that->queriesCount} --- {$this->beautifyQuery($this->insertBindingsIntoQuery($query->sql, $this->formatBindingsForSqlInjection($query->bindings)))}\n");
         });
     }
 

--- a/tests/TestsBase.php
+++ b/tests/TestsBase.php
@@ -137,7 +137,7 @@ class TestsBase extends TestCase
         $that = $this;
         DB::listen(function ($query) use ($that) {
             $that->queriesCount++;
-            // echo("\n--- Query {$that->queriesCount}--- $query->sql\n");
+//             echo("\n--- Query {$that->queriesCount}--- {$this->beautifyQuery($this->insertBindingsIntoQuery($query->sql, $this->formatBindingsForSqlInjection($query->bindings)))}\n");
         });
     }
 


### PR DESCRIPTION
This introduces three new static methods to control the autoload translations behavior.
* `enableAutoloadTranslations()` - forces to load all translations
* `disableAutoloadTranslations()` - disables autoload and returns parent attributes
* `defaultAutoloadTranslations()` - does not change the old behavior logic (*default*)

**solves:**
* #482 
* #483 