### PR TITLE
example in doc for locale filtering in whereTranslation scope

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -349,6 +349,9 @@ Country::listsTranslations('name')->get()->toArray();
 // Filters countries by checking the translation against the given value 
 Country::whereTranslation('name', 'Greece')->first();
 
+// Filters countries by checking the translation against the given value, only in the specified locale
+Country::whereTranslation('name', 'Greece', 'en')->first();
+
 // Or where translation
 Country::whereTranslation('name', 'Greece')->orWhereTranslation('name', 'France')->get();
 


### PR DESCRIPTION
The `whereTranslation` scope allows for a third parameter `$locale` that filters translations in that locale.

I needed that feature to filter slugs in specific locales.

Example:
`example.com/map` -> map page in english
`example.com/sv/karta` -> map page in swedish

The problem is that I was querying the pages model using the slug and `sv/map` would return (correctly) the map page instance, but that's not a correct locale/slug combination.

To make that work using the provided scope it should filter also by locale, which that third parameter enables.

I wasn't aware of it until I went into the source code to try and fix my problem, and the "fix" was already there.

Docs updated so that anybody with the same issue is aware of the option.