### PR TITLE
Allow translateOrDefault to user app locale

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -44,7 +44,7 @@ trait Translatable
      *
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function translateOrNew($locale)
+    public function translateOrNew($locale = null)
     {
         return $this->getTranslationOrNew($locale);
     }
@@ -265,8 +265,10 @@ trait Translatable
      *
      * @return \Illuminate\Database\Eloquent\Model
      */
-    protected function getTranslationOrNew($locale)
+    protected function getTranslationOrNew($locale = null)
     {
+        $locale = $locale ?: $this->locale();
+
         if (($translation = $this->getTranslation($locale, false)) === null) {
             $translation = $this->getNewTranslation($locale);
         }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -32,7 +32,7 @@ trait Translatable
      *
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function translateOrDefault($locale)
+    public function translateOrDefault($locale = null)
     {
         return $this->getTranslation($locale, true);
     }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -215,6 +215,9 @@ class TranslatableTest extends TestsBase
         $this->assertSame($country->getTranslation('ch', true)->name, 'Griechenland');
         $this->assertSame($country->translateOrDefault('ch')->name, 'Griechenland');
         $this->assertSame($country->getTranslation('ch', false), null);
+
+        $this->app->setLocale('ch');
+        $this->assertSame($country->translateOrDefault()->name, 'Griechenland');
     }
 
     public function test_fallback_option_in_config_overrides_models_fallback_option()

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -344,6 +344,9 @@ class TranslatableTest extends TestsBase
     {
         $country = Country::find(1)->first();
         $this->assertSame('abc', $country->translateOrNew('abc')->locale);
+
+        $this->app->setLocale('xyz');
+        $this->assertSame('xyz', $country->translateOrNew()->locale);
     }
 
     public function test_it_returns_if_attribute_is_translated()


### PR DESCRIPTION
Currently the `translateOrDefault` method requires a local parameter.
This PR adds a default value of  `null` to the locale parameter.

This way the locale defaults to the current `app.locale`. It also adds consistency with the `translate` method.