### PR TITLE
Fix ordering example in README which doesn't work

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -524,7 +524,7 @@ A tip here is to make the MySQL query first and then do the Eloquent one.
 To fetch a list of records ordered by a translated field, you can do this: 
 
 ```mysql
-SELECT * from countries
+SELECT countries.*, t.name from countries
 JOIN country_translations as t on t.country_id = countries.id 
 WHERE locale = 'en'
 GROUP BY countries.id
@@ -534,7 +534,8 @@ ORDER BY t.name desc
 The corresponding eloquent query would be:
 
 ```php
-Country::join('country_translations as t', function ($join) {
+Country::select(['countries.*', 't.name'])
+    ->join('country_translations as t', function ($join) {
         $join->on('countries.id', '=', 't.country_id')
             ->where('t.locale', '=', 'en');
     }) 


### PR DESCRIPTION
Existing example messed up the ability to call `- >getTranslation()` on the fetched models.

The problem was that by leaving the default `select *`, everything gets selected by both the regular and translated table. This meant that there would be a duplicate `id` column, and the later `id` column "wins" and takes over for being present in the `$attributes` of the model.

This is a problem, because although the regular table's id and translated table's country_id columns are connected, country.id is just a useless auto incrementing integer that's hardly used, and only used to satisfy Eloquent which doesn't support compound ids (as far as I know).

It may seem like the original example in the README would work, but that's only when you access the translated members directly (e.g. `$country->name`) because of the attributes being present on the country model itself due to `select *` with the join. But as soon as you'd try to call a method like `$country->getTranslation()`, it would then try to use the (failed) eagerly loaded country translations whose country_ids were looked up by the country_translations' id (!) columns which make no sense, and thus you'd always get `NULL`.