### PR TITLE
Add nullable to country name column example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,7 @@ Schema::create('country_translations', function(Blueprint $table)
 {
     $table->increments('id');
     $table->integer('country_id')->unsigned();
-    $table->string('name');
+    $table->string('name')->nullable();
     $table->string('locale')->index();
 
     $table->unique(['country_id','locale']);


### PR DESCRIPTION
The translatable attributes should be nullable.
if you fill one language it will throw exception `The name field does not have default value`