### PR TITLE
Update to Laravel 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "5.6.*|5.7.*"
+        "illuminate/support": "5.6.*|5.7.*|5.8.*"
     },
     "require-dev": {
-        "orchestra/testbench": "3.6.*|3.7.*",
-        "phpunit/phpunit": "~7.0"
+        "dms/phpunit-arraysubset-asserts": "^0.1.0",
+        "orchestra/testbench": "3.6.*|3.7.*|3.8.*"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ This is a Laravel package for translatable models. Its goal is to remove the com
 
  Laravel  | Translatable
 :---------|:----------
+ 5.8      | 9.*
  5.7      | 9.*
  5.6      | 9.*
  5.5      | 8.*

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -52,11 +52,11 @@ class ScopesTest extends TestsBase
         App::setLocale('de');
         App::make('config')->set('translatable.to_array_always_loads_translations', false);
 
-        $list = [[
-            'id'   => '1',
-            'name' => 'Griechenland',
-        ]];
-        $this->assertArraySubset($list, Country::listsTranslations('name')->get()->toArray());
+        $arr = Country::listsTranslations('name')->get()->toArray();
+
+        $this->assertEquals(1, count($arr));
+        $this->assertEquals('1', $arr[0]['id']);
+        $this->assertEquals('Griechenland', $arr[0]['name']);
     }
 
     public function test_lists_of_translated_fields_with_fallback()
@@ -73,7 +73,16 @@ class ScopesTest extends TestsBase
             'id'   => 2,
             'name' => 'France',
         ]];
-        $this->assertArraySubset($list, $country->listsTranslations('name')->get()->toArray());
+
+        $arr = $country->listsTranslations('name')->get()->toArray();
+
+        $this->assertEquals(2, count($arr));
+
+        $this->assertEquals(1, $arr[0]['id']);
+        $this->assertEquals('Griechenland', $arr[0]['name']);
+
+        $this->assertEquals(2, $arr[1]['id']);
+        $this->assertEquals('France', $arr[1]['name']);
     }
 
     public function test_lists_of_translated_fields_disable_autoload_translations()
@@ -125,7 +134,18 @@ class ScopesTest extends TestsBase
             ['name' => 'Zucchini', 'locale' => 'de'],
             ['name' => 'Zucchetti', 'locale' => 'de-CH'],
         ];
-        $this->assertArraySubset($expectedTranslations, $result['translations']);
+        $translations = $result['translations'];
+
+        $this->assertEquals(3, count($translations));
+
+        $this->assertEquals('en', $translations[0]['locale']);
+        $this->assertEquals('zucchini', $translations[0]['name']);
+
+        $this->assertEquals('de', $translations[1]['locale']);
+        $this->assertEquals('Zucchini', $translations[1]['name']);
+
+        $this->assertEquals('de-CH', $translations[2]['locale']);
+        $this->assertEquals('Zucchetti', $translations[2]['name']);
     }
 
     public function test_whereTranslation_filters_by_translation()

--- a/tests/TestCoreModelExtension.php
+++ b/tests/TestCoreModelExtension.php
@@ -38,22 +38,20 @@ class TestCoreModelExtension extends TestsBase
 
     // Failing saving
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_it_throws_query_exception_if_code_is_null()
     {
+        $this->expectException('\Exception');
+
         $country = new Country();
         $country->name = 'Belgium';
         $country->code = null;
         $country->save();
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_it_throws_query_exception_if_saving_and_name_is_null()
     {
+        $this->expectException('\Exception');
+
         $country = new Country();
         $country->code = 'be';
         $country->name = null;
@@ -88,21 +86,19 @@ class TestCoreModelExtension extends TestsBase
 
     // Filling
 
-    /**
-     * @expectedException Illuminate\Database\Eloquent\MassAssignmentException
-     */
     public function test_it_throws_exception_if_filling_a_protected_property()
     {
+        $this->expectException(Illuminate\Database\Eloquent\MassAssignmentException::class);
+
         $country = new CountryGuarded();
         $this->assertTrue($country->totallyGuarded());
         $country->fill(['code' => 'it', 'en' => ['name' => 'Italy']]);
     }
 
-    /**
-     * @expectedException Illuminate\Database\Eloquent\MassAssignmentException
-     */
     public function test_translation_throws_exception_if_filling_a_protected_property()
     {
+        $this->expectException(Illuminate\Database\Eloquent\MassAssignmentException::class);
+
         $country = new Country();
         $country->translationModel = Model\CountryTranslationGuarded::class;
         $country->fill(['code' => 'it', 'en' => ['name' => 'Italy']]);

--- a/tests/TestsBase.php
+++ b/tests/TestsBase.php
@@ -13,7 +13,7 @@ class TestsBase extends TestCase
     const DB_USERNAME = 'homestead';
     const DB_PASSWORD = 'secret';
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->makeSureDatabaseExists(static::DB_NAME);
 

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -220,7 +220,6 @@ class TranslatableTest extends TestsBase
     public function test_it_skips_mass_assignment_if_attributes_non_fillable()
     {
         $this->expectException(Illuminate\Database\Eloquent\MassAssignmentException::class);
-        
         $data = [
             'code' => 'be',
             'en'   => ['name' => 'Belgium'],

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -217,11 +217,10 @@ class TranslatableTest extends TestsBase
         $this->assertEquals('Belgique', $country->translate('fr')->name);
     }
 
-    /**
-     * @expectedException Illuminate\Database\Eloquent\MassAssignmentException
-     */
     public function test_it_skips_mass_assignment_if_attributes_non_fillable()
     {
+        $this->expectException(Illuminate\Database\Eloquent\MassAssignmentException::class);
+        
         $data = [
             'code' => 'be',
             'en'   => ['name' => 'Belgium'],
@@ -376,11 +375,10 @@ class TranslatableTest extends TestsBase
         $this->assertSame($country->getTranslation('en'), null);
     }
 
-    /**
-     * @expectedException Dimsav\Translatable\Exception\LocalesNotDefinedException
-     */
     public function test_if_locales_are_not_defined_throw_exception()
     {
+        $this->expectException(Dimsav\Translatable\Exception\LocalesNotDefinedException::class);
+
         $this->app->config->set('translatable.locales', []);
         new Country(['code' => 'pl']);
     }


### PR DESCRIPTION
- Removes the direct dependency on phpunit
(since is required by orchestra/testbench)
- Update tests to support phpunit 8.0.0 (some methods were deprecated)