### PR TITLE
fetch single translation and hide translation attribute

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -896,6 +896,8 @@ trait Translatable
     {
         $attributes = parent::attributesToArray();
         $this->addHidden(['translation']);
+        $fallbackTrans = false;
+
         foreach ($this->translatedAttributes as $field) {
             if (in_array($field, $this->getHidden())) {
                 continue;
@@ -906,11 +908,15 @@ trait Translatable
                 continue;
             }
 
-            if ($this->usePropertyFallback() && ($trans = $this->translation($this->getFallbackLocale())->first())) {
-                $attributes[$field] = $trans->$field;
-                continue;
+            if ($this->usePropertyFallback()) {
+                if ($fallbackTrans === false) {
+                    $fallbackTrans = $this->translation($this->getFallbackLocale())->limit(1)->first();
+                }
+                if ($fallbackTrans) {
+                    $attributes[$field] = $fallbackTrans->$field;
+                    continue;
+                }
             }
-
             $attributes[$field] = null;
         }
 

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -895,13 +895,23 @@ trait Translatable
     private function attributesToArrayForCurrentTranslation()
     {
         $attributes = parent::attributesToArray();
-        $this->addHidden(['translation']); // we don't need this
+        $this->addHidden(['translation']);
         foreach ($this->translatedAttributes as $field) {
             if (in_array($field, $this->getHidden())) {
                 continue;
             }
 
-            $attributes[$field] = $this->translation->$field;
+            if (!empty($this->translation->$field)) {
+                $attributes[$field] = $this->translation->$field;
+                continue;
+            }
+
+            if ($this->usePropertyFallback() && ($trans = $this->translation($this->getFallbackLocale())->first())) {
+                $attributes[$field] = $trans->$field;
+                continue;
+            }
+
+            $attributes[$field] = null;
         }
 
         return $attributes;


### PR DESCRIPTION
links: #309 #505 

1. added new option **to_array_always_loads_translation** that will override **to_array_always_loads_translations**
1. added new relation translation() that will fetch current locale
1. on hidration to json will use translation() relation and hide translation attribute


## Example

### was
`return City::limit(2)->with('translations')->get();`
```
select
  *
from
  `geoip_city_translation`
where
  `geoip_city_translation`.`city_id` in (1, 2)
```
```
[
    {
        "id": 1,
        "geoname_id": 2803476,
        "continent_code": "EU",
        "country_iso_code": "DE",
        "subdivision_1_iso_code": "SN",
        "subdivision_2_iso_code": null,
        "metro_code": null,
        "time_zone": "Europe/Berlin",
        "is_in_european_union": 1,
        "continent_name": "Europe",
        "country_name": "Germany",
        "subdivision_1_name": "Saxony",
        "subdivision_2_name": null,
        "city_name": "Zwoenitz",
        "translations": [
            {
                "id": 8692,
                "city_id": 1,
                "geoname_id": 2803476,
                "lang": "de",
                "continent_name": "Europa",
                "country_name": "Deutschland",
                "subdivision_1_name": "Sachsen",
                "subdivision_2_name": null,
                "city_name": "Zwönitz"
            },
            {
                "id": 1,
                "city_id": 1,
                "geoname_id": 2803476,
                "lang": "en",
                "continent_name": "Europe",
                "country_name": "Germany",
                "subdivision_1_name": "Saxony",
                "subdivision_2_name": null,
                "city_name": "Zwoenitz"
            }
        ]
    },
```

### becomes
```
    'to_array_always_loads_translations' => true,
    'to_array_always_loads_translation' => true, // <--- add to config  new option
```
`return City::limit(2)->with('translation')->get();`
```
select
  *
from
  `geoip_city_translation`
where
  `lang` = "en"
  and `geoip_city_translation`.`city_id` in (1, 2)
```
```
[
    {
        "id": 1,
        "geoname_id": 2803476,
        "continent_code": "EU",
        "country_iso_code": "DE",
        "subdivision_1_iso_code": "SN",
        "subdivision_2_iso_code": null,
        "metro_code": null,
        "time_zone": "Europe/Berlin",
        "is_in_european_union": 1,
        "continent_name": "Europe",
        "country_name": "Germany",
        "subdivision_1_name": "Saxony",
        "subdivision_2_name": null,
        "city_name": "Zwoenitz"
    },
```

-------------

My current trait over existing

```
namespace App\Models;

use Dimsav\Translatable\Translatable;
use Illuminate\Database\Eloquent\Relations\HasOne;

trait TranslatableTrait
{
    use Translatable {
        attributesToArray as attributeToArrayOriginal;
    }

    /**
     * @return HasOne
     */
    public function translation($locale = null)
    {
        if (!$locale) {
            $locale = $this->locale();
        }

        return $this->hasOne($this->getTranslationModelName(), $this->getRelationKey())
            ->where($this->getLocaleKey(), $locale);
    }

    /**
     * {@inheritdoc}
     */
    public function attributesToArray()
    {
        if (!config('translatable.to_array_always_loads_translation', false)) {
            return $this->attributeToArrayOriginal();
        }

        $attributes = parent::attributesToArray();
        $this->addHidden(['translation']);
        $fallbackTrans = false;

        foreach ($this->translatedAttributes as $field) {
            if (in_array($field, $this->getHidden())) {
                continue;
            }

            if (!empty($this->translation->$field)) {
                $attributes[$field] = $this->translation->$field;
                continue;
            }

            if ($this->usePropertyFallback()) {
                if ($fallbackTrans === false) {
                    $fallbackTrans = $this->translation($this->getFallbackLocale())->limit(1)->first();
                }
                if ($fallbackTrans) {
                    $attributes[$field] = $fallbackTrans->$field;
                    continue;
                }
            }
            $attributes[$field] = null;
        }

        return $attributes;
    }
}
```
